### PR TITLE
Lazy load interpreter steps

### DIFF
--- a/compiler-explorer/src/slangWrapper.ts
+++ b/compiler-explorer/src/slangWrapper.ts
@@ -1,6 +1,20 @@
-import { jargonStepsT } from "./InterpreterJargon";
+import { Steps as i2Steps } from "./Interpreter2";
+import { StreamWrapper as I3StreamWrapper } from "./Interpreter3";
+import { StreamWrapper as JargonStreamWrapper } from "./InterpreterJargon";
 
 export type code = [number, string][];
+
+export type Stream<T> = {
+  steps: T;
+  next: () => Stream<T>;
+};
+
+function jsonParsedStream<T>(s: Stream<string>): Stream<T> {
+  return {
+    steps: JSON.parse(s.steps).reverse(),
+    next: () => jsonParsedStream(s.next()),
+  };
+}
 
 //@ts-ignore
 export const interp = (s: string) => slang.interp0(s);
@@ -17,21 +31,21 @@ export const jargonCompile = (s: string): code =>
   //@ts-ignore
   JSON.parse(slang.jargonCode(s));
 
-export const computeI2steps = (s: string): [string[], string[], string[]][] => {
+export const i2Stream = (s: string): Stream<i2Steps> => {
   //@ts-ignore
-  return JSON.parse(slang.interp2(s));
+  return jsonParsedStream(slang.i2Stream(s));
 };
 
-export const computeI3steps = (
-  s: string
-): [string, [number, string[], string[]][]] => {
+export const i3Stream = (s: string): I3StreamWrapper => {
   //@ts-ignore
-  return JSON.parse(slang.interp3(s));
+  const { code, stepStream } = slang.i3Stream(s);
+  return { code, stepStream: jsonParsedStream(stepStream) };
 };
 
-export const computeJargonSteps = (s: string): jargonStepsT => {
+export const jargonStream = (s: string): JargonStreamWrapper => {
   //@ts-ignore
-  return JSON.parse(slang.jargon(s));
+  const { code, stepStream } = slang.jargonStream(s);
+  return { code: JSON.parse(code), stepStream: jsonParsedStream(stepStream) };
 };
 
 export function stringOfCode(c: code) {

--- a/web/JargonSteps.ml
+++ b/web/JargonSteps.ml
@@ -1,6 +1,7 @@
 open Slang
 open Jargon
 open Ast
+open Js_of_ocaml
 
 type node_tp =
   | H_INT
@@ -156,6 +157,35 @@ let steps exp =
   let c = drop_tag_of_code @@ compile exp in
   let vm = Jargon.first_frame (Jargon.initial_state c) in
   (string_list_of_code vm, driver 1 vm)
+
+
+(* Export a representation of each interpreter step in a stream *)
+
+let rec nsteps vm states n =
+  if n = 0 then (vm, states) else
+  if vm.Jargon.status != Jargon.Running then (vm, states) else
+  let state = string_lists_of_vm_state vm in
+  nsteps (step vm) (state :: states) (n - 1)
+
+let js_string_of_states states = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: ret list] states
+
+let rec streamDriver' vm states n =
+  let (vm', new_states) = nsteps vm states n in
+  (object%js
+    val a = js_string_of_states new_states
+    method next = streamDriver' vm' new_states n
+  end)
+
+let streamDriver exp n =
+  let c = drop_tag_of_code @@ compile exp in
+  let vm = Jargon.first_frame (Jargon.initial_state c) in
+  (object%js
+    val code = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: string list] @@ string_list_of_code vm
+    val stepStream = streamDriver' vm [] n
+  end)
+
+
+(* Generate strings of code with location data for the frontend *)
 
 let location_string_list_of_instruction : Past.loc instruction -> (int * string) = function
   | UNARY({pos_lnum = lnum; _}, op) -> (lnum, "\tUNARY " ^ (string_of_uop op))

--- a/web/export.ml
+++ b/web/export.ml
@@ -1,6 +1,8 @@
 open Js_of_ocaml
 open Slang
 
+let stepCount = 40
+
 let wrap interp str =
   try interp str
   with 
@@ -13,7 +15,6 @@ let wrap_yojson_string f = Js.string (
 
 let yojson_of_location_instructions x = Yojson.Safe.to_string @@ [%yojson_of: (int * string) list] @@ x
 
-type egg = EGG [@@deriving yojson]
 let frontend str = Front_end.front_end_from_string (Js.to_string str)
 let _ =
   Js.export "slang"
@@ -34,4 +35,8 @@ let _ =
         (Interp_3.reset(); yojson_of_location_instructions @@ (Interp3.loc_string_list_of_code  (Interp_3.compile (frontend x))))) str)
       method jargonCode  str = Js.string (wrap (fun x ->
         (Jargon.reset(); yojson_of_location_instructions @@ JargonSteps.location_string_list_of_code (Jargon.compile (frontend x)))) str)
+
+      method i2Stream str = Interp2.streamDriver (frontend str) stepCount
+      method i3Stream str = Interp3.streamDriver (frontend str) stepCount
+      method jargonStream str = JargonSteps.streamDriver (frontend str) stepCount
     end)

--- a/web/interp2.ml
+++ b/web/interp2.ml
@@ -4,6 +4,8 @@ open Interp_2
 
 type 'a steps = 'a Interp_2.interp_state list
 
+let initial_state c = (c, Interp_2.initial_env, Interp_2.initial_state)
+
 let rec driver state =
   match state with
     | ([], _, _) -> [state]
@@ -11,7 +13,7 @@ let rec driver state =
 
 let steps e =
   let c = Interp_2.compile e
-  in driver (c, Interp_2.initial_env, Interp_2.initial_state)
+  in driver (initial_state c)
 
 let string_list_of_code code = List.map Interp_2.string_of_instruction code
 
@@ -22,6 +24,34 @@ let list_of_map m = List.of_seq @@ Seq.map (fun (_, v) -> v) @@ Interp_2.IntMap.
 let string_list_of_heap (heap, _) = List.map Interp_2.string_of_value (list_of_map heap)
 
 let string_lists_of_steps steps = List.map (fun (c, e, s) -> (string_list_of_code c, string_list_of_env e, string_list_of_heap s)) steps
+
+let js_string_of_steps steps = Js_of_ocaml.Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: (string list * string list * string list) list] @@ string_lists_of_steps steps
+
+
+
+(* Export a representation of each interpreter step in a stream *)
+
+let rec nsteps states n =
+  match (n, states) with
+    | (_, []) -> []
+    | (_, ([], _, _)::_) -> states
+    | (0, _) -> states
+    | (n, state::_) -> nsteps (Interp_2.step state :: states) (n-1)
+
+let rec streamDriver' states n =
+  let new_states = (nsteps states n) in
+   (object%js
+     val steps = js_string_of_steps new_states
+     method next = streamDriver' new_states n
+  end)
+
+let streamDriver e n =
+  let c = Interp_2.compile e in
+  streamDriver' [(initial_state c)] n
+
+
+
+(* Generate strings of code with location data for the frontend *)
 
 let apply_to_last f l = let length = List.length l - 1 in List.mapi (fun i x -> if length = i then f x else x) l
 

--- a/web/interp2.mli
+++ b/web/interp2.mli
@@ -11,3 +11,5 @@ val string_lists_of_steps : 'a steps -> (string list * string list * string list
 val loc_string_list_of_instruction : Past.loc Interp_2.instruction -> (int * string) list
 
 val loc_string_list_of_code : Past.loc Interp_2.code -> (int * string) list
+
+val streamDriver : 'a Ast.expr -> int -> string Util.stream

--- a/web/util.ml
+++ b/web/util.ml
@@ -1,0 +1,5 @@
+(* Don't be afraid of this ugly type. It creates a stream like object in js.*)
+type 'a stream = <
+   steps : Js_of_ocaml.Js.js_string Js_of_ocaml.Js.t Js_of_ocaml.Js.readonly_prop;
+   next : 'b Js_of_ocaml.Js.meth
+> Js_of_ocaml.Js.t as 'b


### PR DESCRIPTION
This prevents the site from crashing when the number of steps in the interpreter's evaluations is too big or if the program indicated doesn't terminate.