### PR TITLE
Error handling

### DIFF
--- a/compiler-explorer/package.json
+++ b/compiler-explorer/package.json
@@ -5,10 +5,12 @@
   "dependencies": {
     "@atlaskit/progress-indicator": "^9.0.5",
     "@monaco-editor/react": "^4.2.1",
+    "@patched/hookrouter": "^1.6.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/cytoscape": "^3.14.17",
+    "@types/hookrouter": "^2.2.5",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",

--- a/compiler-explorer/src/App.css
+++ b/compiler-explorer/src/App.css
@@ -3,8 +3,15 @@
   display: flex;
   color: #d4d4d4;
   overflow-y: hidden;
+  background-color: #1e1e1e;
 }
 
+html,
+body {
+  height: 100%;
+}
+
+select,
 button {
   color: #3dc9b0;
   border-style: solid;
@@ -49,4 +56,14 @@ p {
   text-align: left;
   padding-left: 20px;
   margin: 10px 0;
+}
+
+.sourceLineDec {
+  color: rgb(47, 247, 234);
+  width: 100% !important;
+  margin-left: 3px;
+}
+
+.sourceLineDec::before {
+  content: ">>";
 }

--- a/compiler-explorer/src/App.css
+++ b/compiler-explorer/src/App.css
@@ -32,7 +32,17 @@ button {
   width: 25%;
 }
 
-.resultBox {
+.landing {
+  text-align: left;
+  display: flex;
+  color: #3dc9b0;
+  flex-direction: column;
+  justify-content: space-evenly;
+  width: 50%;
+  padding: 30px;
+}
+
+.selectBox {
   height: 6vh;
   display: flex;
   flex-direction: row;

--- a/compiler-explorer/src/App.css
+++ b/compiler-explorer/src/App.css
@@ -39,9 +39,18 @@ button {
   flex-direction: column;
   justify-content: space-evenly;
   width: 50%;
-  padding: 30px;
+  padding: 80px;
 }
 
+.error {
+  width: 50%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  color: rgb(255, 48, 29);
+  text-align: left;
+  white-space: pre-wrap;
+}
 .selectBox {
   height: 6vh;
   display: flex;

--- a/compiler-explorer/src/App.tsx
+++ b/compiler-explorer/src/App.tsx
@@ -40,12 +40,12 @@ export interface SubViewProps {
 }
 
 const subViews: {
-  [key: string]: [string, (s: SubViewProps) => JSX.Element];
+  [key: string]: string;
 } = {
-  allViews: ["All", IntermediateSteps],
-  interp2: ["Interpreter 2", Interpreter2],
-  interp3: ["Interpreter 3", Interpreter3],
-  jargon: ["Jargon", InterpreterJargon],
+  allViews: "All",
+  interp2: "Interpreter 2",
+  interp3: "Interpreter 3",
+  jargon: "Jargon",
 };
 
 enum Paths {
@@ -180,10 +180,10 @@ function App() {
             value={path}
             onChange={(e) => navigate(e.target.value + encodedCode)}
           >
-            <option value={Paths.root}>{subViews["allViews"][0]}</option>
-            <option value={Paths.interp2}>{subViews["interp2"][0]}</option>
-            <option value={Paths.interp3}>{subViews["interp3"][0]}</option>
-            <option value={Paths.jargon}>{subViews["jargon"][0]}</option>
+            <option value={Paths.root}>{subViews.allViews}</option>
+            <option value={Paths.interp2}>{subViews.interp2}</option>
+            <option value={Paths.interp3}>{subViews.interp3}</option>
+            <option value={Paths.jargon}>{subViews.jargon}</option>
           </select>
         </div>
       </div>

--- a/compiler-explorer/src/App.tsx
+++ b/compiler-explorer/src/App.tsx
@@ -12,6 +12,7 @@ import InterpreterJargon from "./InterpreterJargon";
 import { code, highlightRowsForLocation } from "./slangWrapper";
 import Editor from "./Editor";
 import IntermediateSteps from "./IntermediateSteps";
+import LandingPage from "./Landing";
 
 import "./App.css";
 
@@ -55,7 +56,7 @@ enum Paths {
 }
 type routerParams = { code: string; step: number };
 const routes = {
-  "/": () => [Paths.root, IntermediateSteps, encode(fib)],
+  "/": () => [Paths.root, LandingPage, encode(fib)],
   "/:code": ({ code }: routerParams) => [Paths.root, IntermediateSteps, code],
   "/interp2": () => [Paths.interp2, Interpreter2, encode(fib)],
   "/interp2/:code": ({ code }: routerParams) => [
@@ -174,7 +175,7 @@ function App() {
             scrollBeyondLastLine: false,
           }}
         />
-        <div className="resultBox">
+        <div className="selectBox">
           <select
             value={path}
             onChange={(e) => navigate(e.target.value + encodedCode)}

--- a/compiler-explorer/src/App.tsx
+++ b/compiler-explorer/src/App.tsx
@@ -4,58 +4,52 @@ import { useMonaco } from "@monaco-editor/react";
 
 import languageDef from "./LanguageDef";
 import samplePrograms from "./SamplePrograms";
-import { useKeypress } from "./util";
 import Interpreter2 from "./Interpreter2";
 import Interpreter3 from "./Interpreter3";
 import InterpreterJargon from "./InterpreterJargon";
 import "./App.css";
-import {
-  code,
-  highlightRowsForLocation,
-  i2compile,
-  i3compile,
-  interp,
-  jargonCompile,
-  stringOfCode,
-} from "./slangWrapper";
+import { code, highlightRowsForLocation } from "./slangWrapper";
 import Editor from "./Editor";
+import IntermediateSteps from "./IntermediateSteps";
 
 const { fib } = samplePrograms;
-// TODO: fix slang crash bug
-// //@ts-ignore
-// for (const property in slang) {
-//   //@ts-ignore
-//   slang[property] = (...args: any[]) => {
-//     try {
-//       //@ts-ignore
-//       return slang[property](...args)
-//     } catch {
-//       return "\"stack overflow\""
-//     }
-//   }
-// }
 
 type sourceHighlight = {
   highlight: boolean;
   line: number;
 };
 
+export interface SubViewProps {
+  source: string;
+  onMouseMove: (code: code) => (event: any) => void;
+  onMouseLeave: () => void;
+  decorations: (code: code) => (
+    e: any,
+    m: any
+  ) => {
+    range: any;
+    options: {
+      isWholeLine: boolean;
+      linesDecorationsClassName: string;
+    };
+  }[];
+}
+
+const subViews: {
+  [key: string]: [string, (s: SubViewProps) => JSX.Element];
+} = {
+  allViews: ["All", IntermediateSteps],
+  interp2: ["Interpreter 2", Interpreter2],
+  interp3: ["Interpreter 3", Interpreter3],
+  jargon: ["Jargon", InterpreterJargon],
+};
+
 function App() {
   const [volatileSource, setSource] = useState(fib);
   const [source] = useDebounce(volatileSource, 1000);
 
-  const [result, setResult] = useState("");
-
-  const [i2code, setI2code] = useState(i2compile(source));
-  const i2codeString = stringOfCode(i2code).slice(1, -1);
-  const [i3code, setI3code] = useState(i3compile(source));
-  const i3codeString = stringOfCode(i3code);
-  const [jargonCode, setJargonCode] = useState(jargonCompile(source));
-  const jargonCodeString = stringOfCode(jargonCode);
-
-  const [showI2, setShowI2] = useState(false);
-  const [showI3, setShowI3] = useState(false);
-  const [showJargon, setShowJargon] = useState(false);
+  const [subView, setSubView] = useState("allViews");
+  const SubViewElement = subViews[subView][1];
 
   const [volatileSourceHighlight, setSourceHighlight] =
     useState<sourceHighlight>({
@@ -76,7 +70,7 @@ function App() {
       range: new m.Range(l + 1, 1, l + 1, 1),
       options: {
         isWholeLine: true,
-        linesDecorationsClassName: "currentLineDec",
+        linesDecorationsClassName: "sourceLineDec",
       },
     }));
   };
@@ -89,17 +83,11 @@ function App() {
         range: new m.Range(sourceHighlight.line, 1, sourceHighlight.line, 1),
         options: {
           isWholeLine: true,
-          linesDecorationsClassName: "currentLineDec",
+          linesDecorationsClassName: "sourceLineDec",
         },
       },
     ];
   };
-
-  useKeypress(["Escape"], () => {
-    setShowI2(false);
-    setShowI3(false);
-    setShowJargon(false);
-  });
 
   const monaco = useMonaco();
 
@@ -108,13 +96,6 @@ function App() {
     monaco?.languages.register({ id: "Slang" });
     monaco?.languages.setMonarchTokensProvider("Slang", languageDef);
   }, [monaco]);
-
-  useEffect(() => {
-    setResult("");
-    setI2code(i2compile(source));
-    setI3code(i3compile(source));
-    setJargonCode(jargonCompile(source));
-  }, [source]);
 
   const onMouseMove = (code: code) => (event: any) => {
     const lineNumber = event?.target?.position?.lineNumber;
@@ -131,7 +112,7 @@ function App() {
   return (
     <div className="App">
       <div className="editorWrapper">
-        <h4>Slang</h4>
+        <h4>Source</h4>
         <Editor
           height="86vh"
           defaultValue={source}
@@ -145,84 +126,24 @@ function App() {
           options={{
             theme: "vs-dark",
             minimap: { enabled: false },
+            scrollBeyondLastLine: false,
           }}
         />
         <div className="resultBox">
-          <button disabled={!!result} onClick={() => setResult(interp(source))}>
-            {result === "" ? "Compute Result" : result}
-          </button>
+          <select value={subView} onChange={(e) => setSubView(e.target.value)}>
+            <option value="allViews">{subViews["allViews"][0]}</option>
+            <option value="interp2">{subViews["interp2"][0]}</option>
+            <option value="interp3">{subViews["interp3"][0]}</option>
+            <option value="jargon">{subViews["jargon"][0]}</option>
+          </select>
         </div>
       </div>
-      <div className="editorWrapper">
-        <h4>Interpreter 2</h4>
-        <Editor
-          defaultLanguage="javascript"
-          height="86vh"
-          value={i2codeString}
-          onMouseMove={onMouseMove(i2code)}
-          onMouseLeave={onMouseLeave}
-          decorations={decorationsTargetHandler(i2code)}
-          options={{
-            tabSize: 2,
-            readOnly: true,
-            theme: "vs-dark",
-            minimap: { enabled: false },
-          }}
-        />
-        <button onClick={() => setShowI2(!showI2)}>
-          Visualize Interpretation
-        </button>
-      </div>
-      <div className="editorWrapper">
-        <h4>Interpreter 3</h4>
-        <Editor
-          defaultLanguage="javascript"
-          value={i3codeString}
-          onMouseMove={onMouseMove(i3code)}
-          onMouseLeave={onMouseLeave}
-          decorations={decorationsTargetHandler(i3code)}
-          height="86vh"
-          options={{
-            readOnly: true,
-            theme: "vs-dark",
-            minimap: { enabled: false },
-          }}
-        />
-        <button onClick={() => setShowI3(!showI3)}>
-          Visualize Interpretation
-        </button>
-      </div>
-      <div className="editorWrapper">
-        <h4>Jargon</h4>
-        <Editor
-          defaultLanguage="javascript"
-          value={jargonCodeString}
-          onMouseMove={onMouseMove(jargonCode)}
-          onMouseLeave={onMouseLeave}
-          decorations={decorationsTargetHandler(jargonCode)}
-          height="86vh"
-          options={{
-            readOnly: true,
-            theme: "vs-dark",
-            minimap: { enabled: false },
-          }}
-        />
-        <button onClick={() => setShowJargon(!showJargon)}>
-          Visualize Interpretation
-        </button>
-      </div>
-      {showI2 ? (
-        <Interpreter2 source={source} onClose={() => setShowI2(false)} />
-      ) : null}
-      {showI3 ? (
-        <Interpreter3 source={source} onClose={() => setShowI3(false)} />
-      ) : null}
-      {showJargon ? (
-        <InterpreterJargon
-          source={source}
-          onClose={() => setShowJargon(false)}
-        />
-      ) : null}
+      <SubViewElement
+        source={source}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        decorations={decorationsTargetHandler}
+      />
     </div>
   );
 }

--- a/compiler-explorer/src/IntermediateSteps.tsx
+++ b/compiler-explorer/src/IntermediateSteps.tsx
@@ -14,7 +14,12 @@ const IntermediateSteps = ({
   onMouseLeave,
 }: SubViewProps) => {
   const i2code = i2compile(source);
+
+  if (i2code[0][1].toLowerCase().startsWith("error")) {
+    return <div className="error">{i2code[0][1]}</div>;
+  }
   const i2codeString = stringOfCode(i2code).slice(1, -1);
+
   const i3code = i3compile(source);
   const i3codeString = stringOfCode(i3code);
   const jargonCode = jargonCompile(source);

--- a/compiler-explorer/src/IntermediateSteps.tsx
+++ b/compiler-explorer/src/IntermediateSteps.tsx
@@ -1,0 +1,78 @@
+import { SubViewProps } from "./App";
+import Editor from "./Editor";
+import {
+  i2compile,
+  i3compile,
+  jargonCompile,
+  stringOfCode,
+} from "./slangWrapper";
+
+const IntermediateSteps = ({
+  source,
+  decorations,
+  onMouseMove,
+  onMouseLeave,
+}: SubViewProps) => {
+  const i2code = i2compile(source);
+  const i2codeString = stringOfCode(i2code).slice(1, -1);
+  const i3code = i3compile(source);
+  const i3codeString = stringOfCode(i3code);
+  const jargonCode = jargonCompile(source);
+  const jargonCodeString = stringOfCode(jargonCode);
+
+  return (
+    <>
+      <div className="editorWrapper">
+        <h4>Interpreter 2</h4>
+        <Editor
+          defaultLanguage="javascript"
+          height="86vh"
+          value={i2codeString}
+          onMouseMove={onMouseMove(i2code)}
+          onMouseLeave={onMouseLeave}
+          decorations={decorations(i2code)}
+          options={{
+            tabSize: 2,
+            readOnly: true,
+            theme: "vs-dark",
+            minimap: { enabled: false },
+          }}
+        />
+      </div>
+      <div className="editorWrapper">
+        <h4>Interpreter 3</h4>
+        <Editor
+          defaultLanguage="javascript"
+          value={i3codeString}
+          onMouseMove={onMouseMove(i3code)}
+          onMouseLeave={onMouseLeave}
+          decorations={decorations(i3code)}
+          height="86vh"
+          options={{
+            readOnly: true,
+            theme: "vs-dark",
+            minimap: { enabled: false },
+          }}
+        />
+      </div>
+      <div className="editorWrapper">
+        <h4>Jargon</h4>
+        <Editor
+          defaultLanguage="javascript"
+          value={jargonCodeString}
+          onMouseMove={onMouseMove(jargonCode)}
+          onMouseLeave={onMouseLeave}
+          decorations={decorations(jargonCode)}
+          height="86vh"
+          options={{
+            readOnly: true,
+            theme: "vs-dark",
+            minimap: { enabled: false },
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+export default IntermediateSteps;

--- a/compiler-explorer/src/Interpreter2.tsx
+++ b/compiler-explorer/src/Interpreter2.tsx
@@ -52,6 +52,7 @@ const Interpreter2 = ({
 
   useEffect(() => {
     setStream(i2Stream(source));
+    setStep(0);
   }, [source]);
 
   useEffect(() => {

--- a/compiler-explorer/src/Interpreter3.tsx
+++ b/compiler-explorer/src/Interpreter3.tsx
@@ -46,6 +46,7 @@ const Interpreter3 = ({
 
   useEffect(() => {
     setStream(i3Stream(source));
+    setStep(0);
   }, [source]);
 
   useEffect(() => {
@@ -60,7 +61,6 @@ const Interpreter3 = ({
   }, [step, code, next, currentInst, cleanCode, steps.length]);
 
   const decorationsHandler = (e: any, m: Monaco) => {
-    e.revealRange(new m.Range(currentInst, 1, currentInst, 1));
     return [
       {
         range: new m.Range(currentInst + 1, 1, currentInst + 1, 1),

--- a/compiler-explorer/src/Interpreter3.tsx
+++ b/compiler-explorer/src/Interpreter3.tsx
@@ -7,8 +7,9 @@ import Editor from "./Editor";
 import { i3Stream, Stream } from "./slangWrapper";
 
 import "./Stacks.css";
+import { SubViewProps } from "./App";
 
-type Code = string;
+type Code = [number, string][];
 type CodePointer = number;
 type EnvStack = string[];
 type Memory = string[];
@@ -21,11 +22,10 @@ export type StreamWrapper = {
 
 const Interpreter3 = ({
   source,
-  onClose,
-}: {
-  source: string;
-  onClose?: () => void;
-}) => {
+  onMouseMove,
+  onMouseLeave,
+  decorations,
+}: SubViewProps) => {
   const [
     {
       code,
@@ -36,7 +36,7 @@ const Interpreter3 = ({
 
   const [step, setStep] = useState(0);
   const [currentInst, envStack, memory] = steps[step];
-  const cleanCode = clean(code);
+  const cleanCode = code.map(([_, s]) => s).join("\n");
 
   const envStackS = envStack.join("\n");
   const memoryS = memory.join("\n");
@@ -69,6 +69,7 @@ const Interpreter3 = ({
           linesDecorationsClassName: "currentLineDec",
         },
       },
+      ...decorations(code)(e, m),
     ];
   };
 
@@ -78,7 +79,6 @@ const Interpreter3 = ({
         <h3>
           Step {step} - {}
         </h3>
-        {onClose ? <button onClick={onClose}>X</button> : null}
       </div>
       <div className="interpreterEditors">
         <Editor
@@ -86,6 +86,8 @@ const Interpreter3 = ({
           language="javascript"
           onKeyDown={(e) => handler(e.key)}
           decorations={decorationsHandler}
+          onMouseMove={onMouseMove(code)}
+          onMouseLeave={onMouseLeave}
           options={{
             readOnly: true,
             lineNumbers: (lineNumber: number) => (lineNumber - 1).toString(),
@@ -121,13 +123,5 @@ const Interpreter3 = ({
     </div>
   );
 };
-
-function clean(code: string): string {
-  return code
-    .split("\n")
-    .map((i) => i.split(" ").slice(1).join(" "))
-    .filter((i) => i.length > 0)
-    .join("\n");
-}
 
 export default Interpreter3;

--- a/compiler-explorer/src/InterpreterJargon.tsx
+++ b/compiler-explorer/src/InterpreterJargon.tsx
@@ -92,6 +92,7 @@ const InterpreterJargon = ({
 
   useEffect(() => {
     setStream(jargonStream(source));
+    setStep(0);
   }, [source]);
 
   useEffect(() => {
@@ -112,11 +113,6 @@ const InterpreterJargon = ({
   });
 
   const codeDecorationsHandler = (e: any, m: any) => {
-    e.revealRange(new m.Range(currentInst, 1, currentInst, 1));
-    e.setPosition({
-      column: 0,
-      lineNumber: currentInst,
-    });
     return [
       {
         range: new m.Range(currentInst, 1, currentInst, 1),

--- a/compiler-explorer/src/Landing.tsx
+++ b/compiler-explorer/src/Landing.tsx
@@ -1,0 +1,22 @@
+const LandingPage = () => (
+  <div className="landing">
+    <h1>Slang Compiler Explorer</h1>
+    <p>
+      This online tool demonstrates the compilation stages taught in the Part II
+      compilers course. It also demonstrates how the virtual machines for each
+      of the stages execute their representations.
+    </p>
+    <p>
+      Edit the source on the left to get started or choose an interpreter to
+      visualize its execution execution. Choose the interpreter using the select
+      on the bottom left.
+    </p>
+    <p>
+      Use the arrow keys to navigate evaluation steps (as long as the editor on
+      the left is not in focus).
+    </p>
+    <p>Programs are encoded in the url so they can easily be shared.</p>
+  </div>
+);
+
+export default LandingPage;

--- a/compiler-explorer/src/SamplePrograms.ts
+++ b/compiler-explorer/src/SamplePrograms.ts
@@ -9,7 +9,9 @@ const samplePrograms = {
     end
 in
     fib(1)
-end`,
+end
+
+(* Edit me to get started *)`,
 
   fun: `(* the reason we need closures on the heap ... *) 
 
@@ -39,7 +41,7 @@ in
    let x : int = 10 in
       let  y : int = 2 in gcd(x, y) end
     end
-end`
+end`,
 };
 
 export default samplePrograms;

--- a/compiler-explorer/src/Stacks.css
+++ b/compiler-explorer/src/Stacks.css
@@ -1,25 +1,21 @@
 .interpreter {
-  background-color: #1e1e1e;
-  position: fixed;
-  height: 100%;
-  width: 100%;
+  height: 100vh;
+  width: 75%;
 }
 
 .interpreterEditors {
   display: flex;
   flex-direction: row;
   flex-grow: 1;
-  width: 100%;
-  height: 90%;
+  height: 85vh;
 }
 
 .interpreterTitle {
-  height: 5%;
+  height: 8vh;
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-direction: row;
-  padding: 0 10px 0 10px;
 }
 
 .interpreterTitle > h3 {
@@ -68,7 +64,7 @@
 }
 
 .progress {
-  height: 5%;
+  height: 7vh;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/compiler-explorer/src/slangWrapper.ts
+++ b/compiler-explorer/src/slangWrapper.ts
@@ -1,6 +1,20 @@
-import { jargonStepsT } from "./InterpreterJargon";
+import { Steps as i2Steps } from "./Interpreter2";
+import { StreamWrapper as I3StreamWrapper } from "./Interpreter3";
+import { StreamWrapper as JargonStreamWrapper } from "./InterpreterJargon";
 
 export type code = [number, string][];
+
+export type Stream<T> = {
+  steps: T;
+  next: () => Stream<T>;
+};
+
+function jsonParsedStream<T>(s: Stream<string>): Stream<T> {
+  return {
+    steps: JSON.parse(s.steps).reverse(),
+    next: () => jsonParsedStream(s.next()),
+  };
+}
 
 //@ts-ignore
 export const interp = (s: string) => slang.interp0(s);
@@ -17,21 +31,21 @@ export const jargonCompile = (s: string): code =>
   //@ts-ignore
   JSON.parse(slang.jargonCode(s));
 
-export const computeI2steps = (s: string): [string[], string[], string[]][] => {
+export const i2Stream = (s: string): Stream<i2Steps> => {
   //@ts-ignore
-  return JSON.parse(slang.interp2(s));
+  return jsonParsedStream(slang.i2Stream(s));
 };
 
-export const computeI3steps = (
-  s: string
-): [string, [number, string[], string[]][]] => {
+export const i3Stream = (s: string): I3StreamWrapper => {
   //@ts-ignore
-  return JSON.parse(slang.interp3(s));
+  const { code, stepStream } = slang.i3Stream(s);
+  return { code, stepStream: jsonParsedStream(stepStream) };
 };
 
-export const computeJargonSteps = (s: string): jargonStepsT => {
+export const jargonStream = (s: string): JargonStreamWrapper => {
   //@ts-ignore
-  return JSON.parse(slang.jargon(s));
+  const { code, stepStream } = slang.jargonStream(s);
+  return { code: JSON.parse(code), stepStream: jsonParsedStream(stepStream) };
 };
 
 export function stringOfCode(c: code) {

--- a/compiler-explorer/src/slangWrapper.ts
+++ b/compiler-explorer/src/slangWrapper.ts
@@ -4,6 +4,10 @@ import { StreamWrapper as JargonStreamWrapper } from "./InterpreterJargon";
 
 export type code = [number, string][];
 
+export type Error = {
+  error: string;
+};
+
 export type Stream<T> = {
   steps: T;
   next: () => Stream<T>;
@@ -31,20 +35,28 @@ export const jargonCompile = (s: string): code =>
   //@ts-ignore
   JSON.parse(slang.jargonCode(s));
 
-export const i2Stream = (s: string): Stream<i2Steps> => {
+export const i2Stream = (s: string): Stream<i2Steps> | Error => {
   //@ts-ignore
-  return jsonParsedStream(slang.i2Stream(s));
+  const stream = slang.i2Stream(s);
+  if (stream.steps.startsWith("Error")) return { error: stream.steps };
+  return jsonParsedStream(stream);
 };
 
-export const i3Stream = (s: string): I3StreamWrapper => {
+export const i3Stream = (s: string): I3StreamWrapper | Error => {
   //@ts-ignore
-  const { code, stepStream } = slang.i3Stream(s);
+  const streamWrapper = slang.i3Stream(s);
+  if (streamWrapper.code.startsWith("Error"))
+    return { error: streamWrapper.code };
+  const { code, stepStream } = streamWrapper;
   return { code: JSON.parse(code), stepStream: jsonParsedStream(stepStream) };
 };
 
-export const jargonStream = (s: string): JargonStreamWrapper => {
+export const jargonStream = (s: string): JargonStreamWrapper | Error => {
   //@ts-ignore
-  const { code, stepStream } = slang.jargonStream(s);
+  const streamWrapper = slang.jargonStream(s);
+  if (streamWrapper.code.startsWith("Error"))
+    return { error: streamWrapper.code };
+  const { code, stepStream } = streamWrapper;
   return { code: JSON.parse(code), stepStream: jsonParsedStream(stepStream) };
 };
 

--- a/compiler-explorer/src/slangWrapper.ts
+++ b/compiler-explorer/src/slangWrapper.ts
@@ -39,7 +39,7 @@ export const i2Stream = (s: string): Stream<i2Steps> => {
 export const i3Stream = (s: string): I3StreamWrapper => {
   //@ts-ignore
   const { code, stepStream } = slang.i3Stream(s);
-  return { code, stepStream: jsonParsedStream(stepStream) };
+  return { code: JSON.parse(code), stepStream: jsonParsedStream(stepStream) };
 };
 
 export const jargonStream = (s: string): JargonStreamWrapper => {

--- a/compiler-explorer/yarn.lock
+++ b/compiler-explorer/yarn.lock
@@ -1600,6 +1600,11 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@patched/hookrouter@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@patched/hookrouter/-/hookrouter-1.6.0.tgz#a440dd39e42d45c20721f1060bdab47756d64da7"
+  integrity sha512-Lq2TL0yMHATAdJfIErvXu2Oj7kBp8dKPAV6xEikHWjyjO1vk2Mi//4Tp/fBx+GAOMd8k0XkMolEzQdzVuzMvzA==
+
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -1889,6 +1894,14 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/hookrouter@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@types/hookrouter/-/hookrouter-2.2.5.tgz#f04dafd1e073da01ba85f79100c41de530969cea"
+  integrity sha512-uesCRVHgugHtpfdtXWcNH60gCvn7qwQVap6s2KtHRZ8uhDJear8osTmgImATc5aOUC6iNWJzeYMSvGUc/lFf2A==
+  dependencies:
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"

--- a/web/JargonSteps.ml
+++ b/web/JargonSteps.ml
@@ -1,6 +1,7 @@
 open Slang
 open Jargon
 open Ast
+open Js_of_ocaml
 
 type node_tp =
   | H_INT
@@ -156,6 +157,35 @@ let steps exp =
   let c = drop_tag_of_code @@ compile exp in
   let vm = Jargon.first_frame (Jargon.initial_state c) in
   (string_list_of_code vm, driver 1 vm)
+
+
+(* Export a representation of each interpreter step in a stream *)
+
+let rec nsteps vm states n =
+  if n = 0 then (vm, states) else
+  if vm.Jargon.status != Jargon.Running then (vm, states) else
+  let state = string_lists_of_vm_state vm in
+  nsteps (step vm) (state :: states) (n - 1)
+
+let js_string_of_states states = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: ret list] states
+
+let rec streamDriver' vm states n =
+  let (vm', new_states) = nsteps vm states n in
+  (object%js
+    val a = js_string_of_states new_states
+    method next = streamDriver' vm' new_states n
+  end)
+
+let streamDriver exp n =
+  let c = drop_tag_of_code @@ compile exp in
+  let vm = Jargon.first_frame (Jargon.initial_state c) in
+  (object%js
+    val code = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: string list] @@ string_list_of_code vm
+    val stepStream = streamDriver' vm [] n
+  end)
+
+
+(* Generate strings of code with location data for the frontend *)
 
 let location_string_list_of_instruction : Past.loc instruction -> (int * string) = function
   | UNARY({pos_lnum = lnum; _}, op) -> (lnum, "\tUNARY " ^ (string_of_uop op))

--- a/web/JargonSteps.ml
+++ b/web/JargonSteps.ml
@@ -206,6 +206,7 @@ let rec streamDriver' vm states n =
   end)
 
 let streamDriver exp n =
+  Jargon.reset();
   let c = compile exp in
   let vm = Jargon.first_frame (Jargon.initial_state @@ drop_tag_of_code c) in
   (object%js

--- a/web/JargonSteps.ml
+++ b/web/JargonSteps.ml
@@ -147,44 +147,6 @@ let string_lists_of_vm_state vm_state = match vm_state with {
 
 let string_list_of_code vm_state = List.map Jargon.string_of_instruction (Array.to_list vm_state.code)
 
-let rec driver n vm =
-  let state = string_lists_of_vm_state vm in
-  state :: if vm.Jargon.status = Jargon.Running then driver (n+1) (step vm) else []
-
-let drop_tag_of_code c = List.map (Jargon.map (fun _ -> ())) c
-
-let steps exp =
-  let c = drop_tag_of_code @@ compile exp in
-  let vm = Jargon.first_frame (Jargon.initial_state c) in
-  (string_list_of_code vm, driver 1 vm)
-
-
-(* Export a representation of each interpreter step in a stream *)
-
-let rec nsteps vm states n =
-  if n = 0 then (vm, states) else
-  if vm.Jargon.status != Jargon.Running then (vm, states) else
-  let state = string_lists_of_vm_state vm in
-  nsteps (step vm) (state :: states) (n - 1)
-
-let js_string_of_states states = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: ret list] states
-
-let rec streamDriver' vm states n =
-  let (vm', new_states) = nsteps vm states n in
-  (object%js
-    val a = js_string_of_states new_states
-    method next = streamDriver' vm' new_states n
-  end)
-
-let streamDriver exp n =
-  let c = drop_tag_of_code @@ compile exp in
-  let vm = Jargon.first_frame (Jargon.initial_state c) in
-  (object%js
-    val code = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: string list] @@ string_list_of_code vm
-    val stepStream = streamDriver' vm [] n
-  end)
-
-
 (* Generate strings of code with location data for the frontend *)
 
 let location_string_list_of_instruction : Past.loc instruction -> (int * string) = function
@@ -213,3 +175,41 @@ let location_string_list_of_instruction : Past.loc instruction -> (int * string)
               -> (lnum, "MK_CLOSURE(" ^ (string_of_location loc) ^ ", " ^ (string_of_int n) ^ ")")
 
 let location_string_list_of_code = List.map location_string_list_of_instruction
+
+let rec driver n vm =
+  let state = string_lists_of_vm_state vm in
+  state :: if vm.Jargon.status = Jargon.Running then driver (n+1) (step vm) else []
+
+let drop_tag_of_code c = List.map (Jargon.map (fun _ -> ())) c
+
+let steps exp =
+  let c = drop_tag_of_code @@ compile exp in
+  let vm = Jargon.first_frame (Jargon.initial_state c) in
+  (string_list_of_code vm, driver 1 vm)
+
+
+(* Export a representation of each interpreter step in a stream *)
+
+let rec nsteps vm states n =
+  if n = 0 then (vm, states) else
+  if vm.Jargon.status != Jargon.Running then (vm, states) else
+  let state = string_lists_of_vm_state vm in
+  nsteps (step vm) (state :: states) (n - 1)
+
+let js_string_of_states states = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: ret list] states
+
+let rec streamDriver' vm states n =
+  let (vm', new_states) = nsteps vm states n in
+  (object%js
+    val steps = js_string_of_states new_states
+    method next = streamDriver' vm' new_states n
+  end)
+
+let streamDriver exp n =
+  let c = compile exp in
+  let vm = Jargon.first_frame (Jargon.initial_state @@ drop_tag_of_code c) in
+  (object%js
+    val code = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: (int * string) list] @@ location_string_list_of_code c
+    val stepStream = streamDriver' vm [] n
+  end)
+

--- a/web/JargonSteps.ml
+++ b/web/JargonSteps.ml
@@ -214,3 +214,7 @@ let streamDriver exp n =
     val stepStream = streamDriver' vm [] n
   end)
 
+let err s = (object%js
+  val code = Js.string @@ "Error: " ^ s
+  val stepStream = Util.errStream s
+end)

--- a/web/export.ml
+++ b/web/export.ml
@@ -23,7 +23,7 @@ let _ =
         (Interp_0.string_of_value (Interp_0.interpret_top_level (frontend x)))) str)
         
       method interp2     str = wrap_yojson_string (fun _ -> (
-        [%yojson_of: (string list * string list * string list) list] (Interp2.string_lists_of_steps (Interp2.steps @@ frontend str))))
+        [%yojson_of: ((int * string) list * string list * string list) list] (Interp2.loc_string_lists_of_steps (Interp2.steps @@ frontend str))))
       method interp3     str = wrap_yojson_string (fun _ -> ( Interp_3.reset();
         ([%yojson_of: string * (int * string list * string list) list] (Interp3.stacks (frontend str)))))
       method jargon      str = wrap_yojson_string (fun _ -> (Jargon.reset();

--- a/web/export.ml
+++ b/web/export.ml
@@ -1,6 +1,8 @@
 open Js_of_ocaml
 open Slang
 
+let stepCount = 40
+
 let wrap interp str =
   try interp str
   with 
@@ -13,7 +15,6 @@ let wrap_yojson_string f = Js.string (
 
 let yojson_of_location_instructions x = Yojson.Safe.to_string @@ [%yojson_of: (int * string) list] @@ x
 
-type egg = EGG [@@deriving yojson]
 let frontend str = Front_end.front_end_from_string (Js.to_string str)
 let _ =
   Js.export "slang"
@@ -34,4 +35,8 @@ let _ =
         (Interp_3.reset(); yojson_of_location_instructions @@ (Interp3.loc_string_list_of_code  (Interp_3.compile (frontend x))))) str)
       method jargonCode  str = Js.string (wrap (fun x ->
         (Jargon.reset(); yojson_of_location_instructions @@ JargonSteps.location_string_list_of_code (Jargon.compile (frontend x)))) str)
+
+      method i2Stream str = Interp2.streamDriver (frontend str) stepCount
+      method i3Stream str = Interp3.streamDriver (frontend str) stepCount
+      method jargonStream str = JargonSteps.streamDriver (frontend str) stepCount
     end)

--- a/web/export.ml
+++ b/web/export.ml
@@ -3,15 +3,17 @@ open Slang
 
 let stepCount = 40
 
-let wrap interp str =
+let wrapCode interp str =
   try interp str
   with 
-    | Errors.Error s -> "[[0, \"" ^ String.trim s ^ "\"]]"
+    | Errors.Error s -> "[[0, \"Error:\\n" ^ String.trim s ^ "\"]]"
+    | Failure s -> "[[0, \"Error:\\n" ^ String.trim s ^ "\"]]"
 
-let wrap_yojson_string f = Js.string (
-  try (Yojson.Safe.to_string (f()))
-  with Errors.Error _ -> "\"Error\""
-)
+let wrapInterp f errReplacement = 
+  try f ()
+  with
+    | Errors.Error s -> errReplacement s
+    | Failure s -> errReplacement s
 
 let yojson_of_location_instructions x = Yojson.Safe.to_string @@ [%yojson_of: (int * string) list] @@ x
 
@@ -19,24 +21,14 @@ let frontend str = Front_end.front_end_from_string (Js.to_string str)
 let _ =
   Js.export "slang"
     (object%js
-      method interp0     str = Js.string (wrap (fun x ->
-        (Interp_0.string_of_value (Interp_0.interpret_top_level (frontend x)))) str)
-        
-      method interp2     str = wrap_yojson_string (fun _ -> (
-        [%yojson_of: ((int * string) list * string list * string list) list] (Interp2.loc_string_lists_of_steps (Interp2.steps @@ frontend str))))
-      method interp3     str = wrap_yojson_string (fun _ -> ( Interp_3.reset();
-        ([%yojson_of: string * (int * string list * string list) list] (Interp3.stacks (frontend str)))))
-      method jargon      str = wrap_yojson_string (fun _ -> (Jargon.reset();
-        ([%yojson_of: string list * JargonSteps.ret list] (JargonSteps.steps (frontend str)))))
-
-      method interp2Code str = Js.string (wrap (fun x ->
+      method interp2Code str = Js.string (wrapCode (fun x ->
         (yojson_of_location_instructions @@ Interp2.loc_string_list_of_code (Interp_2.compile (frontend x)))) str)
-      method interp3Code str = Js.string (wrap (fun x ->
+      method interp3Code str = Js.string (wrapCode (fun x ->
         (Interp_3.reset(); yojson_of_location_instructions @@ (Interp3.loc_string_list_of_code  (Interp_3.compile (frontend x))))) str)
-      method jargonCode  str = Js.string (wrap (fun x ->
+      method jargonCode  str = Js.string (wrapCode (fun x ->
         (Jargon.reset(); yojson_of_location_instructions @@ JargonSteps.location_string_list_of_code (Jargon.compile (frontend x)))) str)
 
-      method i2Stream str = Interp2.streamDriver (frontend str) stepCount
-      method i3Stream str = Interp3.streamDriver (frontend str) stepCount
-      method jargonStream str = JargonSteps.streamDriver (frontend str) stepCount
+      method i2Stream str = wrapInterp (fun _ -> Interp2.streamDriver (frontend str) stepCount) Util.errStream
+      method i3Stream str = wrapInterp (fun _ -> Interp3.streamDriver (frontend str) stepCount) Interp3.err
+      method jargonStream str = wrapInterp (fun _ -> JargonSteps.streamDriver (frontend str) stepCount) JargonSteps.err
     end)

--- a/web/export.ml
+++ b/web/export.ml
@@ -6,7 +6,7 @@ let stepCount = 40
 let wrap interp str =
   try interp str
   with 
-    | Errors.Error s -> s
+    | Errors.Error s -> "[[0, \"" ^ String.trim s ^ "\"]]"
 
 let wrap_yojson_string f = Js.string (
   try (Yojson.Safe.to_string (f()))

--- a/web/interp2.ml
+++ b/web/interp2.ml
@@ -4,6 +4,8 @@ open Interp_2
 
 type 'a steps = 'a Interp_2.interp_state list
 
+let initial_state c = (c, Interp_2.initial_env, Interp_2.initial_state)
+
 let rec driver state =
   match state with
     | ([], _, _) -> [state]
@@ -11,7 +13,7 @@ let rec driver state =
 
 let steps e =
   let c = Interp_2.compile e
-  in driver (c, Interp_2.initial_env, Interp_2.initial_state)
+  in driver (initial_state c)
 
 let string_list_of_code code = List.map Interp_2.string_of_instruction code
 
@@ -22,6 +24,34 @@ let list_of_map m = List.of_seq @@ Seq.map (fun (_, v) -> v) @@ Interp_2.IntMap.
 let string_list_of_heap (heap, _) = List.map Interp_2.string_of_value (list_of_map heap)
 
 let string_lists_of_steps steps = List.map (fun (c, e, s) -> (string_list_of_code c, string_list_of_env e, string_list_of_heap s)) steps
+
+let js_string_of_steps steps = Js_of_ocaml.Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: (string list * string list * string list) list] @@ string_lists_of_steps steps
+
+
+
+(* Export a representation of each interpreter step in a stream *)
+
+let rec nsteps states n =
+  match (n, states) with
+    | (_, []) -> []
+    | (_, ([], _, _)::_) -> states
+    | (0, _) -> states
+    | (n, state::_) -> nsteps (Interp_2.step state :: states) (n-1)
+
+let rec streamDriver' states n =
+  let new_states = (nsteps states n) in
+   (object%js
+     val steps = js_string_of_steps new_states
+     method next = streamDriver' new_states n
+  end)
+
+let streamDriver e n =
+  let c = Interp_2.compile e in
+  streamDriver' [(initial_state c)] n
+
+
+
+(* Generate strings of code with location data for the frontend *)
 
 let apply_to_last f l = let length = List.length l - 1 in List.mapi (fun i x -> if length = i then f x else x) l
 

--- a/web/interp2.mli
+++ b/web/interp2.mli
@@ -2,14 +2,14 @@ open Slang
 
 type 'a steps = 'a Interp_2.interp_state list
 
-val steps : 'a Ast.expr -> 'a steps
+val steps : Past.loc Ast.expr -> Past.loc steps
  
 val string_list_of_heap : 'a Interp_2.state -> string list
 
-val string_lists_of_steps : 'a steps -> (string list * string list * string list) list
+val loc_string_lists_of_steps : Past.loc steps -> ((int * string) list * string list * string list) list
 
 val loc_string_list_of_instruction : Past.loc Interp_2.instruction -> (int * string) list
 
 val loc_string_list_of_code : Past.loc Interp_2.code -> (int * string) list
 
-val streamDriver : 'a Ast.expr -> int -> string Util.stream
+val streamDriver : Past.loc Ast.expr -> int -> string Util.stream

--- a/web/interp2.mli
+++ b/web/interp2.mli
@@ -11,3 +11,5 @@ val string_lists_of_steps : 'a steps -> (string list * string list * string list
 val loc_string_list_of_instruction : Past.loc Interp_2.instruction -> (int * string) list
 
 val loc_string_list_of_code : Past.loc Interp_2.code -> (int * string) list
+
+val streamDriver : 'a Ast.expr -> int -> string Util.stream

--- a/web/interp2.mli
+++ b/web/interp2.mli
@@ -12,4 +12,4 @@ val loc_string_list_of_instruction : Past.loc Interp_2.instruction -> (int * str
 
 val loc_string_list_of_code : Past.loc Interp_2.code -> (int * string) list
 
-val streamDriver : Past.loc Ast.expr -> int -> string Util.stream
+val streamDriver : Past.loc Ast.expr -> int -> Util.stream

--- a/web/interp3.ml
+++ b/web/interp3.ml
@@ -56,9 +56,9 @@ let stacks e =
 let rec nsteps states n = match (states, n) with
   | ([], _) -> states 
   | (_, 0) -> states
-  | ((cp, env, _)::_, n) -> if Interp_3.HALT () != Interp_3.map (fun _ -> ()) @@ Interp_3.get_instruction cp
-      then let (cp', env') = Interp_3.step (cp, env) in
-        let heapl = list_of_heap() in nsteps ((cp', env', heapl) :: states) (n - 1) else states
+  | ((cp, env, _)::_, n) -> if Interp_3.HALT () = Interp_3.map (fun _ -> ()) @@ Interp_3.get_instruction cp
+      then states else let (cp', env') = Interp_3.step (cp, env) in
+        let heapl = list_of_heap() in nsteps ((cp', env', heapl) :: states) (n - 1)
 
 let js_string_of_states states = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: (int * string list * string list) list] @@ List.map int_string_list_string_list_list_of_state states
 
@@ -70,6 +70,7 @@ let rec streamDriver' states n =
   end)
 
 let streamDriver e n =
+  Interp_3.reset();
   let c = Interp_3.compile e in
   let _ = Interp_3.installed := Interp_3.load (drop_tag_of_code c) in
   (object%js

--- a/web/interp3.ml
+++ b/web/interp3.ml
@@ -79,3 +79,8 @@ let streamDriver e n =
   end)
  
 
+let err s = (object%js
+  val code = Js.string @@ "Error: " ^ s
+  val stepStream = Util.errStream s
+end)
+

--- a/web/interp3.ml
+++ b/web/interp3.ml
@@ -5,6 +5,35 @@ open Ast
 
 let int_string_list_string_list_list_of_state (cp, evs, heap_list) = (cp, List.map Interp_3.string_of_env_or_value evs, List.map Interp_3.string_of_value heap_list)
 
+(* Generate strings of code with location data for the frontend *)
+
+let  loc_string_list_of_instruction : Past.loc instruction -> (int * string) list = function
+  | UNARY({pos_lnum = lnum; _}, op) -> [(lnum, "UNARY " ^ (string_of_uop op))]
+  | OPER({pos_lnum = lnum; _}, op)  -> [(lnum, "OPER " ^ (string_of_bop op))]
+  | MK_PAIR {pos_lnum = lnum; _}   -> [(lnum, "MK_PAIR")]
+  | FST {pos_lnum = lnum; _}    -> [(lnum, "FST")]
+  | SND {pos_lnum = lnum; _}    -> [(lnum, "SND")]
+  | MK_INL {pos_lnum = lnum; _} -> [(lnum, "MK_INL")]
+  | MK_INR {pos_lnum = lnum; _} -> [(lnum, "MK_INR")]
+  | MK_REF {pos_lnum = lnum; _} -> [(lnum, "MK_REF")]
+  | PUSH({pos_lnum = lnum; _}, v)   -> [(lnum, "PUSH " ^ (string_of_value v))]
+  | LOOKUP({pos_lnum = lnum; _}, x) -> [(lnum, "LOOKUP " ^ x)]
+  | TEST({pos_lnum = lnum; _}, label)   -> [(lnum, "TEST " ^ (string_of_location label))]
+  | CASE({pos_lnum = lnum; _}, label)   -> [(lnum, "CASE " ^ (string_of_location label))]
+  | GOTO({pos_lnum = lnum; _}, label)   -> [(lnum, "GOTO " ^ (string_of_location label))]
+  | APPLY {pos_lnum = lnum; _}  -> [(lnum, "APPLY")]
+  | RETURN {pos_lnum = lnum; _} -> [(lnum, "RETURN")]
+  | HALT {pos_lnum = lnum; _}   -> [(lnum, "HALT")]
+  | BIND({pos_lnum = lnum; _}, x)   -> [(lnum, "BIND " ^ x)]
+  | LABEL({pos_lnum = lnum; _}, label)  -> [(lnum, "LABEL " ^ label)]
+  | SWAP {pos_lnum = lnum; _}   -> [(lnum, "SWAP")]
+  | POP {pos_lnum = lnum; _}    -> [(lnum, "POP")]
+  | DEREF {pos_lnum = lnum; _}  -> [(lnum, "DEREF")]
+  | ASSIGN {pos_lnum = lnum; _} -> [(lnum, "ASSIGN")]
+  | MK_CLOSURE({pos_lnum = lnum; _}, loc)  -> [(lnum, "MK_CLOSURE(" ^ (string_of_location loc) ^ ")")]
+  | MK_REC({pos_lnum = lnum; _}, v, loc) -> [(lnum, "MK_REC(" ^ v ^ ", " ^ (string_of_location loc) ^ ")")]
+
+let loc_string_list_of_code c =  List.flatten @@ List.map loc_string_list_of_instruction c
 let list_of_heap _ = Array.to_list (Array.sub Interp_3.heap 0 (!Interp_3.next_address))
 
 let drop_tag_of_code c = List.map (Interp_3.map (fun _ -> ())) c
@@ -36,47 +65,16 @@ let js_string_of_states states = Js.string @@ Yojson.Safe.to_string @@ [%yojson_
 let rec streamDriver' states n =
   let new_states = nsteps states n in
   (object%js
-    val a = js_string_of_states new_states
+    val steps = js_string_of_states new_states
     method next = streamDriver' new_states n
   end)
 
 let streamDriver e n =
-  let c = drop_tag_of_code @@ Interp_3.compile e in
-  let _ = Interp_3.installed := Interp_3.load c in
-  let installed_code = Interp_3.string_of_installed_code() in
+  let c = Interp_3.compile e in
+  let _ = Interp_3.installed := Interp_3.load (drop_tag_of_code c) in
   (object%js
-    val installedCode = Js.string installed_code
+    val code = Js.string @@ Yojson.Safe.to_string @@ [%yojson_of: (int * string) list] @@ loc_string_list_of_code c
     val stepStream = streamDriver' [(0, [], [])] n
   end)
  
 
-
-(* Generate strings of code with location data for the frontend *)
-
-let  loc_string_list_of_instruction : Past.loc instruction -> (int * string) list = function
-  | UNARY({pos_lnum = lnum; _}, op) -> [(lnum, "UNARY " ^ (string_of_uop op))]
-  | OPER({pos_lnum = lnum; _}, op)  -> [(lnum, "OPER " ^ (string_of_bop op))]
-  | MK_PAIR {pos_lnum = lnum; _}   -> [(lnum, "MK_PAIR")]
-  | FST {pos_lnum = lnum; _}    -> [(lnum, "FST")]
-  | SND {pos_lnum = lnum; _}    -> [(lnum, "SND")]
-  | MK_INL {pos_lnum = lnum; _} -> [(lnum, "MK_INL")]
-  | MK_INR {pos_lnum = lnum; _} -> [(lnum, "MK_INR")]
-  | MK_REF {pos_lnum = lnum; _} -> [(lnum, "MK_REF")]
-  | PUSH({pos_lnum = lnum; _}, v)   -> [(lnum, "PUSH " ^ (string_of_value v))]
-  | LOOKUP({pos_lnum = lnum; _}, x) -> [(lnum, "LOOKUP " ^ x)]
-  | TEST({pos_lnum = lnum; _}, label)   -> [(lnum, "TEST " ^ (string_of_location label))]
-  | CASE({pos_lnum = lnum; _}, label)   -> [(lnum, "CASE " ^ (string_of_location label))]
-  | GOTO({pos_lnum = lnum; _}, label)   -> [(lnum, "GOTO " ^ (string_of_location label))]
-  | APPLY {pos_lnum = lnum; _}  -> [(lnum, "APPLY")]
-  | RETURN {pos_lnum = lnum; _} -> [(lnum, "RETURN")]
-  | HALT {pos_lnum = lnum; _}   -> [(lnum, "HALT")]
-  | BIND({pos_lnum = lnum; _}, x)   -> [(lnum, "BIND " ^ x)]
-  | LABEL({pos_lnum = lnum; _}, label)  -> [(lnum, "LABEL " ^ label)]
-  | SWAP {pos_lnum = lnum; _}   -> [(lnum, "SWAP")]
-  | POP {pos_lnum = lnum; _}    -> [(lnum, "POP")]
-  | DEREF {pos_lnum = lnum; _}  -> [(lnum, "DEREF")]
-  | ASSIGN {pos_lnum = lnum; _} -> [(lnum, "ASSIGN")]
-  | MK_CLOSURE({pos_lnum = lnum; _}, loc)  -> [(lnum, "MK_CLOSURE(" ^ (string_of_location loc) ^ ")")]
-  | MK_REC({pos_lnum = lnum; _}, v, loc) -> [(lnum, "MK_REC(" ^ v ^ ", " ^ (string_of_location loc) ^ ")")]
-
-let loc_string_list_of_code c =  List.flatten @@ List.map loc_string_list_of_instruction c

--- a/web/util.ml
+++ b/web/util.ml
@@ -1,5 +1,13 @@
+open Js_of_ocaml
+
 (* Don't be afraid of this ugly type. It creates a stream like object in js.*)
-type 'a stream = <
-   steps : Js_of_ocaml.Js.js_string Js_of_ocaml.Js.t Js_of_ocaml.Js.readonly_prop;
-   next : 'b Js_of_ocaml.Js.meth
-> Js_of_ocaml.Js.t as 'b
+type stream = <
+   steps : Js.js_string Js.t Js.readonly_prop;
+   next : stream Js.meth
+> Js_of_ocaml.Js.t
+
+let rec errStream s : stream = (object%js
+  val steps = Js.string ("Error:" ^ s)
+  method next = errStream s
+   end
+)

--- a/web/util.ml
+++ b/web/util.ml
@@ -1,0 +1,5 @@
+(* Don't be afraid of this ugly type. It creates a stream like object in js.*)
+type 'a stream = <
+   steps : Js_of_ocaml.Js.js_string Js_of_ocaml.Js.t Js_of_ocaml.Js.readonly_prop;
+   next : 'b Js_of_ocaml.Js.meth
+> Js_of_ocaml.Js.t as 'b


### PR DESCRIPTION
Depends on #16 

This implements more robust error handling, it now catches lexing errors as well as parsing and type checking errors.

I've implemented this in a very hacky way, replacing strings of json encoded objects with error messages and checking whether those strings begin with "error" before decoding. However, I've hiden this nastiness from the ts side in the slang wrapper. It would be a good idea to use some kind of Either object on the ocaml side and parse this on the ts side but I avoided this in the interest of speed.

I can go back and clean this but this will slow down the pr by about a week because of my other obligations.