### PR TITLE
Remove redundant 'end'

### DIFF
--- a/slang/parser.mly
+++ b/slang/parser.mly
@@ -28,6 +28,7 @@ let get_loc = Parsing.symbol_start_pos
 %start start
 %type <Past.type_expr> texpr
 %type <Past.expr> simple_expr 
+%type <Past.expr> expr1 
 %type <Past.expr> expr 
 %type <Past.expr list> exprlist
 %type <Past.expr> start

--- a/slang/tests/add3.slang
+++ b/slang/tests/add3.slang
@@ -2,4 +2,3 @@
 let add(p : int * int) : int = (fst p) + (snd p)
 in 
   add (1, add (88, 12))
-end 

--- a/slang/tests/add4.slang
+++ b/slang/tests/add4.slang
@@ -3,7 +3,5 @@ let add(p : int * int) : int =
     let h(z : int) : int = z + (snd p)
     in 
        h(fst p)
-    end    
 in 
   add(1, add(88, 12))
-end 

--- a/slang/tests/add5.slang
+++ b/slang/tests/add5.slang
@@ -5,10 +5,5 @@ let add(p : int * int) : int =
        let h(z : int) : int = z + g(snd p) 
        in 
           h(fst p)
-       end    
-   end 
-    
 in 
   add(1, add(88, 12))
-end 
- 

--- a/slang/tests/add6.slang
+++ b/slang/tests/add6.slang
@@ -2,4 +2,3 @@
 let add(p : int * (int * (int * int))) : int = (fst p) + ((fst (snd p)) + (fst (snd (snd p))))
 in 
   add(1, (88, (12, 10000)))
-end 

--- a/slang/tests/add7.slang
+++ b/slang/tests/add7.slang
@@ -4,7 +4,4 @@
 let x : int ref = ref 100 
 in let y : int ref = ref 1 
    in 
-       !x + !y 
-   end 
-end 
-
+       !x + !y

--- a/slang/tests/alpha.slang
+++ b/slang/tests/alpha.slang
@@ -5,8 +5,3 @@ in let x : int = 2 + x
       in let g(x : int) : int = x + x 
          in let h(x : int) : int = x + g(x) 
             in g(h(g(x)))
-            end 
-         end 
-      end 
-   end 
-end 

--- a/slang/tests/expr2.slang
+++ b/slang/tests/expr2.slang
@@ -2,4 +2,3 @@ let minus(p : int * int) : int = (fst p) - (snd p) in
 let plus(p : int * int) : int = (fst p) + (snd p) in 
 let mult(p : int * int) : int = (fst p) * (snd p) in 
    minus(200, mult(9, plus(-3, 14)))
-end end end 

--- a/slang/tests/fib0.slang
+++ b/slang/tests/fib0.slang
@@ -3,9 +3,6 @@ let fib( m : int) : int =
     then 1 
     else if m = 1 
          then 1 
-         else fib (m - 1) + fib (m -2) 
-         end 
-    end 
+         else fib (m - 1) + fib (m -2)   
 in 
     fib(0) 
-end 

--- a/slang/tests/fib1.slang
+++ b/slang/tests/fib1.slang
@@ -4,8 +4,5 @@ let fib( m : int) : int =
     else if m = 1 
          then 1 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
 in 
     fib(1) 
-end 

--- a/slang/tests/fib10.slang
+++ b/slang/tests/fib10.slang
@@ -4,8 +4,5 @@ let fib( m : int) : int =
     else if m = 1 
          then 1 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
 in 
     fib(10) 
-end 

--- a/slang/tests/fib2.slang
+++ b/slang/tests/fib2.slang
@@ -4,8 +4,5 @@ let fib( m : int) : int =
     else if m = 1 
          then 1 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
 in 
     fib(2) 
-end 

--- a/slang/tests/fib3.slang
+++ b/slang/tests/fib3.slang
@@ -4,8 +4,5 @@ let fib( m : int) : int =
     else if m = 1 
          then 1 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
 in 
     fib(3) 
-end 

--- a/slang/tests/fib4.slang
+++ b/slang/tests/fib4.slang
@@ -4,8 +4,5 @@ let fib( m : int) : int =
     else if m = 1 
          then 1 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
 in 
     fib(4) 
-end 

--- a/slang/tests/fib5.slang
+++ b/slang/tests/fib5.slang
@@ -4,8 +4,5 @@ let fib( m : int) : int =
     else if m = 1 
          then 1 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
 in 
     fib(5) 
-end 

--- a/slang/tests/fib5_v2.slang
+++ b/slang/tests/fib5_v2.slang
@@ -6,11 +6,7 @@ let h(p : int * int) : int  =
     else if m = 1
          then snd p 
          else fib (m - 1) + fib (m -2) 
-         end 
-    end 
    in 
       fib(fst p) 
-   end 
 in 
     h(5, 1) 
-end 

--- a/slang/tests/fun.slang
+++ b/slang/tests/fun.slang
@@ -2,11 +2,8 @@
 (* the reason we need closures on the heap ... *) 
 
 let f(y : int) : int -> int =
-  let g(x :int) : int = y + x in g end
+  let g(x :int) : int = y + x in g
 in
   let add21 : int -> int  = f(21) in 
       let add17 : int -> int  = f(17) in 
          add17(3) + add21(60)
-       end 
-  end
-end

--- a/slang/tests/gcd.slang
+++ b/slang/tests/gcd.slang
@@ -7,12 +7,6 @@ let gcd(p : int * int) : int =
           else if m < n 
                then gcd(m, n - m)
                else gcd(m - n, n)
-               end 
-           end 
-       end 
-     end 
 in 
    let x : int = 10 in 
-      let  y : int = 2 in gcd(x, y) end 
-    end 
-end 
+      let  y : int = 2 in gcd(x, y)

--- a/slang/tests/labels.slang
+++ b/slang/tests/labels.slang
@@ -1,4 +1,4 @@
 let L0 (x : int) : int =
-  if x = 0 then 1 else x * L0 (x-1) end
+  if x = 0 then 1 else x * L0 (x-1)
 in
-  L0 1 end
+  L0 1

--- a/slang/tests/labels2.slang
+++ b/slang/tests/labels2.slang
@@ -1,5 +1,5 @@
 let f(x : unit) : int =
   let f (y : int) : int =
-    if y = 0 then 1 else f (y-1) end
-  in f 5 end
-in f () end
+    if y = 0 then 1 else f (y-1)
+  in f 5
+in f ()

--- a/slang/tests/labels3.slang
+++ b/slang/tests/labels3.slang
@@ -1,7 +1,6 @@
 let f (x : int) : int =
-  if x = 0 then 1 else x * f (x-1) end
+  if x = 0 then 1 else x * f (x-1)
 in
   let f (y : int * int) : int =
-    if (fst y) = 0 then 1 else (fst y) * f ((fst y) - 1, 0) end
-  in f (3,0) end end
-
+    if (fst y) = 0 then 1 else (fst y) * f ((fst y) - 1, 0)
+  in f (3,0)

--- a/slang/tests/lambda1.slang
+++ b/slang/tests/lambda1.slang
@@ -1,4 +1,4 @@
 
-(fun (x : int) -> x end) (99 + 2) 
+(fun (x : int) -> x) (99 + 2) 
 
 

--- a/slang/tests/lambda2.slang
+++ b/slang/tests/lambda2.slang
@@ -1,4 +1,4 @@
 
-(fun (p : int * int) -> (fst p) + (snd p) end)(99, 2) 
+(fun (p : int * int) -> (fst p) + (snd p))(99, 2) 
 
 

--- a/slang/tests/lambda3.slang
+++ b/slang/tests/lambda3.slang
@@ -1,2 +1,5 @@
-
-(fun (d : int + int) -> case d of inl (x : int) -> x + 2 | inr (y : int) -> 17 end end) (inl int 99) 
+(fun (d : int + int) -> 
+    case d of 
+        inl (x : int) -> x + 2 
+      | inr (y : int) -> 17 
+    ) (inl int 99) 

--- a/slang/tests/let1.slang
+++ b/slang/tests/let1.slang
@@ -2,6 +2,5 @@ let x : int = 1
 in   (let x : int = 88 
       in 
         x + 12 
-      end) 
+      ) 
    + x 
-end 

--- a/slang/tests/let2.slang
+++ b/slang/tests/let2.slang
@@ -5,6 +5,3 @@ in let y : int = 1
    in begin
         x + y
       end 
-   end 
-end 
-

--- a/slang/tests/nest.slang
+++ b/slang/tests/nest.slang
@@ -3,6 +3,3 @@ let x1 : int = 1
 in let x2 : int = 2 + x1 
    in let x3 : int = 3 + x1 + x2 
       in x3 
-      end 
-   end 
-end 

--- a/slang/tests/nest2.slang
+++ b/slang/tests/nest2.slang
@@ -5,8 +5,3 @@ in let x2 : int = 2 + x1
       in let g(y : int) : int = y + x3 
          in let h(z : int) : int = z + g(z) 
             in g(h(g(x3)))
-            end 
-         end 
-      end 
-   end 
-end 

--- a/slang/tests/ref1.slang
+++ b/slang/tests/ref1.slang
@@ -1,5 +1,5 @@
 
 (* ref, deref *) 
 
-let x : int ref = (ref 50)  in !x + !x + 1 end 
+let x : int ref = (ref 50)  in !x + !x + 1
 

--- a/slang/tests/ref2.slang
+++ b/slang/tests/ref2.slang
@@ -6,5 +6,4 @@ in begin
     x := (ref 101); 
     !!x 
    end 
-end 
 

--- a/slang/tests/ref3.slang
+++ b/slang/tests/ref3.slang
@@ -6,5 +6,4 @@ in begin
     (!x) := 101; 
     !!x 
    end 
-end 
 

--- a/slang/tests/seq0.slang
+++ b/slang/tests/seq0.slang
@@ -5,7 +5,4 @@ let x : int ref = ref 100
 in let y : int ref = ref 1 
    in begin 
         !x + !y
-      end   
-   end 
-end 
-
+      end

--- a/slang/tests/seq1.slang
+++ b/slang/tests/seq1.slang
@@ -8,7 +8,4 @@ in let y : int ref = ref 0
         y := 1; 
         x := 100; 
         !x + !y
-      end   
-   end 
-end 
-
+      end

--- a/slang/tests/seq2.slang
+++ b/slang/tests/seq2.slang
@@ -1,11 +1,8 @@
 
-let x : (int -> int) ref = ref (fun (z : int) -> z + 17 end)
+let x : (int -> int) ref = ref (fun (z : int) -> z + 17)
 in let y : int ref = ref 0 
    in begin 
         y := !x 4; 
-        x := (fun (w : int) -> w * 10 end); 
+        x := (fun (w : int) -> w * 10); 
         ((!x) 8) + !y
-      end 
-   end 
-end 
-
+      end

--- a/slang/tests/stack.slang
+++ b/slang/tests/stack.slang
@@ -4,8 +4,3 @@ let z1(x1: int) : int = x1 + 0 in
     let z4(x4: int) : int = z3(x4) + 3 in  
       let z5(x5: int) : int = z4(x5) + 4 in  
          z5(17) + 5
-      end 
-    end 
-  end 
- end 
-end

--- a/slang/tests/stack2.slang
+++ b/slang/tests/stack2.slang
@@ -4,8 +4,3 @@ let z1(x1: int) : int = x1 - 1 in
     let z4(x4: int) : int = z3(x4) - 4 in  
       let z5(x5: int) : int = z4(x5) - 5 in  
          15 + z5(10 + z4(6 + z3(3 + z2(1 + z1(17)))))
-      end 
-    end 
-  end 
- end 
-end

--- a/slang/tests/while.slang
+++ b/slang/tests/while.slang
@@ -3,8 +3,6 @@ let i : int ref = ref (-100)
 in
   begin
     while !i < 3 do
-      i := (!i + 1)
-    end;
+      i := (!i + 1);
     !i
   end
-end


### PR DESCRIPTION
Removes verbose 'end' after:
- if ... else ...
- while ... do ...
- fun
- let
- case