### PR TITLE
Remove outdated instructions in slang/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![Main workflow](https://github.com/yallop/cc_cl_cam_ac_uk/actions/workflows/test.yml/badge.svg)](https://github.com/yallop/cc_cl_cam_ac_uk/actions/workflows/test.yml)
 
+## Ocaml dependencies
+
+After installing opam, run:
+
+```
+opam install dune ppx_deriving_yojson js_of_ocaml js_of_ocaml-ppx
+```
+
 ## slang-cli
 
 To build the slang compiler:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To build the slang compiler:
 dune build
 ```
 
+See [the slang readme file](slang/README.txt) for instructions on how to run the compiler.
+
 To clean the repo
 
 ```

--- a/slang/README.txt
+++ b/slang/README.txt
@@ -9,33 +9,20 @@ Slang ( = Simple LANGuage), a fragment of the
 language L3 from 1B Semantics.   
 
 ===============================================
-Building 
+Building
 ===============================================
-Install ocamlbuild.  Then do either 
-
-  ocamlbuild slang.byte
-
-or
-
-  ocamlbuild slang.native  
-
-This will build the executable slang.byte (or 
-slang.native) as well as a directory _build 
-of compiled code. 
-
-To clean up, just do 
-
-  ocamlbuild -clean 
-
-Building slang.byte is quicker, but the runtime of 
-slang.native is faster.  However, you probably will 
-not notice the difference on this project. 
+See top level readme for build instructions.
 
 ===============================================
-Usage 
+Usage
 ===============================================
+You can run using the command:
 
-Usage: slang.byte [options] [<file>]
+  dune exec ./slang.exe
+
+See below for detailed usage documentation:
+
+Usage: slang.exe [options] [<file>]
 Options are:
   -V verbose front end
   -v verbose interpreter(s)


### PR DESCRIPTION
`ocamlbuild` is not used anymore (replaced by dune) and the given command gives the error: `Error: Unbound module "Slanglib"`

I've removed references to the bytecode build, since the dune files are currently not set up for that. It could be back if it is useful: https://dune.readthedocs.io/en/latest/quick-start.html#building-a-hello-world-program-in-bytecode

I've also added the `opam` command used to install dune and other required ocaml dependencies.