### PR TITLE
Handle unterminated comments

### DIFF
--- a/slang/lexer.mll
+++ b/slang/lexer.mll
@@ -66,13 +66,13 @@ rule token = parse
   | "(*" { comment lexbuf; token lexbuf }
   | newline { next_line lexbuf; token lexbuf } 
   | eof { EOF }
-  | _ { Errors.complain ("Lexer : Illegal character " ^ (Char.escaped(Lexing.lexeme_char lexbuf 0)))
-}
+  | _ { Errors.complainf "ERROR Lexer : Illegal character %s" (Char.escaped(Lexing.lexeme_char lexbuf 0)) }
 
 and comment = parse
   | "*)" { () }
   | newline { next_line lexbuf; comment lexbuf }
   | "(*" {comment lexbuf; comment lexbuf }
+  | eof { Errors.complain "ERROR Lexer : Comment not terminated at" }
   | _ { comment lexbuf } 
       
 

--- a/slang/lexer.mll
+++ b/slang/lexer.mll
@@ -72,7 +72,7 @@ and comment = parse
   | "*)" { () }
   | newline { next_line lexbuf; comment lexbuf }
   | "(*" {comment lexbuf; comment lexbuf }
-  | eof { Errors.complain "ERROR Lexer : Comment not terminated at" }
+  | eof { Errors.complain "ERROR Lexer : Comment not terminated" }
   | _ { comment lexbuf } 
       
 


### PR DESCRIPTION
The compiler explorer crashes with `exception Failure("lexing: empty token")` when an unterminated comment is entered into the web textbox. Adding an `| eof { ... }` case fixes this issue.

Apparently the error messages also have to be prefixed by `ERROR` in order to not be treated as JSON, so now they will be displayed properly.