### PR TITLE
chore: Add OCamlformat configuration and format codebase

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,3 @@
+profile = default
+version = 0.27.0
+if-then-else = vertical

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
 profile = default
-version = 0.27.0
+version = 0.28.1
 if-then-else = vertical

--- a/basic_transformations/cps.ml
+++ b/basic_transformations/cps.ml
@@ -3,38 +3,36 @@ Compiler Construction 2016
 Computer Laboratory 
 University of Cambridge 
 Timothy G. Griffin (tgg22@cam.ac.uk) 
-*****************************************) 
+*****************************************)
 
-(* fib : int -> int *) 
+(* fib : int -> int *)
 let rec fib m =
-    if m = 0 
-    then 1 
-    else if m = 1 
-         then 1 
-         else fib(m - 1) + fib (m - 2) 
-
+  if m = 0 then
+    1
+  else if m = 1 then
+    1
+  else
+    fib (m - 1) + fib (m - 2)
 
 (* fib_cps : ((int -> int) * int) -> int  
 
    note : fib_cps(f, m) = f(fib m) 
 
-*) 
+*)
 let rec fib_cps (cnt, m) =
-    if m = 0 
-    then cnt 1 
-    else if m = 1 
-         then cnt 1 
-         else fib_cps((fun a -> fib_cps((fun b -> cnt (a + b)), m - 2)),  
-                      m - 1)
+  if m = 0 then
+    cnt 1
+  else if m = 1 then
+    cnt 1
+  else
+    fib_cps ((fun a -> fib_cps ((fun b -> cnt (a + b)), m - 2)), m - 1)
 
-(* the initial continuation *) 
-let id x = x 
+(* the initial continuation *)
+let id x = x
 
 (* 
    fib_1 : int -> int 
 
    note : fib_1 m = fib_cps (id, m) = id(fib m) = fib m. 
-*) 
-let fib_1 m = fib_cps(id, m)
-
-
+*)
+let fib_1 m = fib_cps (id, m)

--- a/basic_transformations/dfc.ml
+++ b/basic_transformations/dfc.ml
@@ -3,7 +3,7 @@ Compiler Construction 2016
 Computer Laboratory 
 University of Cambridge 
 Timothy G. Griffin (tgg22@cam.ac.uk) 
-*****************************************) 
+*****************************************)
 
 (* The "defunctionalisation" (dfc) transformation 
    replaces functions with elements in a data structure. 
@@ -39,43 +39,32 @@ Timothy G. Griffin (tgg22@cam.ac.uk)
 
    where each ei' = dfc(ei). 
 
-*) 
+*)
 
-(* First a very simple example *) 
+(* First a very simple example *)
 
+(* sum : 'a * 'a * ('a -> int) -> int *)
+let sum (a, b, f) = f a + f b
 
-(* sum : 'a * 'a * ('a -> int) -> int *) 
-let sum (a, b, f) = (f a) + (f b) 
+(* test : int * int -> int *)
+let test (x, y) = sum (x, y, fun z -> z * y) * sum (x, y, fun w -> (w * x) + y)
 
-(* test : int * int -> int *) 
-let test (x, y) = 
-      (sum (x, y, fun z -> z * y))
-    * (sum (x, y, fun w -> (w * x) + y))
-
-(* after the dfc transformation : *) 
+(* after the dfc transformation : *)
 
 type funs = FUN1 of int | FUN2 of int * int
 
-(* apply_funs : funs * int -> int *) 
-let apply_funs = function 
-  | (FUN1 y,     z) -> z * y
-  | (FUN2(x, y), w) -> (w * x) + y
+(* apply_funs : funs * int -> int *)
+let apply_funs = function FUN1 y, z -> z * y | FUN2 (x, y), w -> (w * x) + y
 
-(* sum_dfc :  int * int * funs -> int *) 
-let sum_dfc (a, b, f) = apply_funs(f, a) + apply_funs(f, b) 
+(* sum_dfc :  int * int * funs -> int *)
+let sum_dfc (a, b, f) = apply_funs (f, a) + apply_funs (f, b)
 
-(* test_dfc : int * int -> int *) 
-let test_dfc (x, y) = (sum_dfc (x, y, FUN1 y)) * (sum_dfc (x, y, FUN2(x,y)))
-      
+(* test_dfc : int * int -> int *)
+let test_dfc (x, y) = sum_dfc (x, y, FUN1 y) * sum_dfc (x, y, FUN2 (x, y))
+
 (* Observation. 
    We have specialized sum_dfc to a version that only calls 
    the functions used by test, represented now as elements of 
    the datastructure funs.  Thus the type of sum_dfc is not 
    as general as that of sum. 
-*)     
-
-
-
-
-
-
+*)

--- a/basic_transformations/dune
+++ b/basic_transformations/dune
@@ -1,0 +1,21 @@
+(executable
+ (name ackermann)
+ (modules ackermann))
+
+(executable
+ (name cps)
+ (modules cps))
+
+(executable
+ (name dfc)
+ (modules dfc))
+
+(executable
+ (name expr_machine)
+ (modules expr_machine))
+
+(executable
+ (name fibonacci_machine)
+ (modules fibonacci_machine)
+ (preprocess
+  (pps ppx_deriving.show)))

--- a/basic_transformations/expr_machine.ml
+++ b/basic_transformations/expr_machine.ml
@@ -3,7 +3,7 @@ Compiler Construction 2020
 Computer Laboratory 
 University of Cambridge 
 Timothy G. Griffin (tgg22@cam.ac.uk) 
-*****************************************) 
+*****************************************)
 
 (* This file derives a simple expression compiler from 
    a recursive evaluation function.  This is done in 
@@ -29,19 +29,19 @@ Timothy G. Griffin (tgg22@cam.ac.uk)
 
    Note: this improves on an earlier version by including a 
    more detailed description of the transformations eval_5 --> eval_6 --> eval_7. 
-*) 
-
+*)
 
 (* for use below *)
 
-let verbose = ref true 
-			 
-let string_of_list f l = 
-   let rec aux f = function 
-     | [] -> ""
-     | [t] -> (f t)
-     | t :: rest -> (f t) ^ "; " ^ (aux f rest)
-   in "[" ^ (aux f l) ^ "]"
+let verbose = ref true
+
+let string_of_list f l =
+  let rec aux f = function
+    | [] -> ""
+    | [ t ] -> f t
+    | t :: rest -> f t ^ "; " ^ aux f rest
+  in
+  "[" ^ aux f l ^ "]"
 
 (* Datatype for expression 
  
@@ -49,29 +49,29 @@ let string_of_list f l =
 
   PLUS(INT 2, MULT(SUBT(INT 5, INT 1), INT 4))
 
-*) 
-type expr = 
-   | INT of int 
-   | PLUS of expr * expr
-   | SUBT of expr * expr
-   | MULT of expr * expr
+*)
+type expr =
+  | INT of int
+  | PLUS of expr * expr
+  | SUBT of expr * expr
+  | MULT of expr * expr
 
 (* a few expressions for testing *)
-(* 1 + (2 + (3 + (4 + 5))) *) 		      
-let test1 = PLUS(INT 1, PLUS(INT 2, PLUS(INT 3, PLUS(INT 4, INT 5))))
-(* (((1 + 2) + 3) + 4) + 5 *) 		
-let test2 = PLUS(PLUS(PLUS(PLUS(INT 1, INT 2), INT 3), INT 4), INT 5) 
+(* 1 + (2 + (3 + (4 + 5))) *)
+let test1 = PLUS (INT 1, PLUS (INT 2, PLUS (INT 3, PLUS (INT 4, INT 5))))
 
-(* string_of_expr : expr -> string *) 		      
-let rec string_of_expr = function 
-   | INT a          -> string_of_int a
-   | PLUS(e1, e2)   -> "(" ^ (string_of_expr e1) ^ " + " ^ (string_of_expr e2) ^ ")"
-   | SUBT(e1, e2)   -> "(" ^ (string_of_expr e1) ^ " - " ^ (string_of_expr e2) ^ ")"
-   | MULT(e1, e2)   -> "(" ^ (string_of_expr e1) ^ " * " ^ (string_of_expr e2) ^ ")"
+(* (((1 + 2) + 3) + 4) + 5 *)
+let test2 = PLUS (PLUS (PLUS (PLUS (INT 1, INT 2), INT 3), INT 4), INT 5)
 
+(* string_of_expr : expr -> string *)
+let rec string_of_expr = function
+  | INT a -> string_of_int a
+  | PLUS (e1, e2) -> "(" ^ string_of_expr e1 ^ " + " ^ string_of_expr e2 ^ ")"
+  | SUBT (e1, e2) -> "(" ^ string_of_expr e1 ^ " - " ^ string_of_expr e2 ^ ")"
+  | MULT (e1, e2) -> "(" ^ string_of_expr e1 ^ " * " ^ string_of_expr e2 ^ ")"
 
-(******************************* eval **************************************) 
-		      
+(******************************* eval **************************************)
+
 (* eval : expr -> int 
    a simple recursive evaluator for expressions. 
 
@@ -79,42 +79,43 @@ let rec string_of_expr = function
 
    Claim 1 : This interpreter (eval) is correct! 
    Proof: by inspection ;-) 
-*) 
-let rec eval = function 
-   | INT a             -> a 
-   | PLUS(e1, e2)   -> (eval e1) + (eval e2) 
-   | SUBT(e1, e2)   -> (eval e1) - (eval e2) 
-   | MULT(e1, e2)   -> (eval e1) * (eval e2) 
+*)
+let rec eval = function
+  | INT a -> a
+  | PLUS (e1, e2) -> eval e1 + eval e2
+  | SUBT (e1, e2) -> eval e1 - eval e2
+  | MULT (e1, e2) -> eval e1 * eval e2
 
+(******************************* eval_2 **************************************)
 
-(******************************* eval_2 **************************************)  
+(* apply cps transform to the interpreter eval *)
 
-(* apply cps transform to the interpreter eval *) 
+type cnt_2 = int -> int
+type state_2 = expr * cnt_2
 
-type cnt_2   = int -> int 
-type state_2 = expr * cnt_2 
-
-(* eval_aux_2 : state_2 -> int *) 
-let rec eval_aux_2 (e, cnt) = 
-   match e with 
-   | INT a        -> cnt a 
-   | PLUS(e1, e2) -> eval_aux_2(e1, fun v1 -> eval_aux_2(e2, fun v2 -> cnt(v1 + v2)))
-   | SUBT(e1, e2) -> eval_aux_2(e1, fun v1 -> eval_aux_2(e2, fun v2 -> cnt(v1 - v2)))
-   | MULT(e1, e2) -> eval_aux_2(e1, fun v1 -> eval_aux_2(e2, fun v2 -> cnt(v1 * v2)))
+(* eval_aux_2 : state_2 -> int *)
+let rec eval_aux_2 (e, cnt) =
+  match e with
+  | INT a -> cnt a
+  | PLUS (e1, e2) ->
+      eval_aux_2 (e1, fun v1 -> eval_aux_2 (e2, fun v2 -> cnt (v1 + v2)))
+  | SUBT (e1, e2) ->
+      eval_aux_2 (e1, fun v1 -> eval_aux_2 (e2, fun v2 -> cnt (v1 - v2)))
+  | MULT (e1, e2) ->
+      eval_aux_2 (e1, fun v1 -> eval_aux_2 (e2, fun v2 -> cnt (v1 * v2)))
 
 (* 
     Claim 2 : c (eval e) = eval_aux_2(e, c) 
     Proof: by induction on the structure of e.  
-*) 
-      
-(* id_cnt : cnt_2 *) 
-let id_cnt (x : int) = x 
+*)
 
-(*  eval_2 : expr -> int *) 
-let eval_2 e = eval_aux_2(e, id_cnt) 
+(* id_cnt : cnt_2 *)
+let id_cnt (x : int) = x
 
+(*  eval_2 : expr -> int *)
+let eval_2 e = eval_aux_2 (e, id_cnt)
 
-(******************************* eval_3 **************************************) 			 
+(******************************* eval_3 **************************************)
 
 (* Now apply "defunctionalisation" to eval_cps. 
 
@@ -128,48 +129,46 @@ let eval_2 e = eval_aux_2(e, id_cnt)
   < fun v2 -> cnt(v1 + v2) > 
        = INNER_PLUS(v1, < cnt >)
 
-*) 
-type cnt_3 = 
-  | ID 
-  | OUTER_PLUS of expr * cnt_3  
+*)
+type cnt_3 =
+  | ID
+  | OUTER_PLUS of expr * cnt_3
   | OUTER_SUBT of expr * cnt_3
   | OUTER_MULT of expr * cnt_3
-  | INNER_PLUS of int * cnt_3   
+  | INNER_PLUS of int * cnt_3
   | INNER_SUBT of int * cnt_3
   | INNER_MULT of int * cnt_3
 
-type state_3 = expr * cnt_3 
+type state_3 = expr * cnt_3
 
 (* apply_3 : cnt_3 * int -> int 
 
    Claim 3 : For c : cnt_2 and v : int,  c(v) = apply_3(< c >, v) AND 
              for all e, c, eval_aux_2 (e, c) =  eval_aux_3 (e, < c >). 
    Proof : by induction on the structure of < c >. 
-*) 
-let rec apply_3 = function 
-   | (ID,                   v) -> v 
-   | (OUTER_PLUS(e2, cnt), v1) -> eval_aux_3(e2, INNER_PLUS(v1, cnt))
-   | (OUTER_SUBT(e2, cnt), v1) -> eval_aux_3(e2, INNER_SUBT(v1, cnt))
-   | (OUTER_MULT(e2, cnt), v1) -> eval_aux_3(e2, INNER_MULT(v1, cnt))
-   | (INNER_PLUS(v1, cnt), v2) -> apply_3(cnt, v1 + v2) 
-   | (INNER_SUBT(v1, cnt), v2) -> apply_3(cnt, v1 - v2) 
-   | (INNER_MULT(v1, cnt), v2) -> apply_3(cnt, v1 * v2) 
+*)
+let rec apply_3 = function
+  | ID, v -> v
+  | OUTER_PLUS (e2, cnt), v1 -> eval_aux_3 (e2, INNER_PLUS (v1, cnt))
+  | OUTER_SUBT (e2, cnt), v1 -> eval_aux_3 (e2, INNER_SUBT (v1, cnt))
+  | OUTER_MULT (e2, cnt), v1 -> eval_aux_3 (e2, INNER_MULT (v1, cnt))
+  | INNER_PLUS (v1, cnt), v2 -> apply_3 (cnt, v1 + v2)
+  | INNER_SUBT (v1, cnt), v2 -> apply_3 (cnt, v1 - v2)
+  | INNER_MULT (v1, cnt), v2 -> apply_3 (cnt, v1 * v2)
 
 (* eval_aux_2 : state_3 -> int 
-*) 
-and eval_aux_3 (e, cnt) = 
-   match e with 
-   | INT a        -> apply_3(cnt, a) 
-   | PLUS(e1, e2) -> eval_aux_3(e1, OUTER_PLUS(e2, cnt)) 
-   | SUBT(e1, e2) -> eval_aux_3(e1, OUTER_SUBT(e2, cnt)) 
-   | MULT(e1, e2) -> eval_aux_3(e1, OUTER_MULT(e2, cnt)) 
+*)
+and eval_aux_3 (e, cnt) =
+  match e with
+  | INT a -> apply_3 (cnt, a)
+  | PLUS (e1, e2) -> eval_aux_3 (e1, OUTER_PLUS (e2, cnt))
+  | SUBT (e1, e2) -> eval_aux_3 (e1, OUTER_SUBT (e2, cnt))
+  | MULT (e1, e2) -> eval_aux_3 (e1, OUTER_MULT (e2, cnt))
 
-(* eval_3 : expr -> int *) 
-let eval_3 e = eval_aux_3(e, ID) 
+(* eval_3 : expr -> int *)
+let eval_3 e = eval_aux_3 (e, ID)
 
-
-
-(******************************* eval_4 **************************************) 			 
+(******************************* eval_4 **************************************)
 
 (* The cnt_3 type can be thought of as a list containing six 
    kinds of elements (being used by the code like a push/pop stack). 
@@ -183,24 +182,24 @@ let eval_3 e = eval_aux_3(e, ID)
 
    for OP in {PLUS, SUBT, MULT} 
 *)
-			 
-type tag = 
+
+type tag =
   | O_PLUS of expr
-  | I_PLUS of int 
+  | I_PLUS of int
   | O_SUBT of expr
-  | I_SUBT of int 
+  | I_SUBT of int
   | O_MULT of expr
   | I_MULT of int
 
-let string_of_tag = function 
-  | O_PLUS e -> "O+(" ^ (string_of_expr e) ^ ")"
-  | I_PLUS n -> "I+(" ^ (string_of_int n)  ^ ")"
-  | O_SUBT e -> "O-(" ^ (string_of_expr e) ^ ")"		    
-  | I_SUBT n -> "I-(" ^ (string_of_int n)  ^ ")"
-  | O_MULT e -> "O*(" ^ (string_of_expr e) ^ ")"		    
-  | I_MULT n -> "I*(" ^ (string_of_int n)  ^ ")"
-					
-type cnt_4   = tag list 
+let string_of_tag = function
+  | O_PLUS e -> "O+(" ^ string_of_expr e ^ ")"
+  | I_PLUS n -> "I+(" ^ string_of_int n ^ ")"
+  | O_SUBT e -> "O-(" ^ string_of_expr e ^ ")"
+  | I_SUBT n -> "I-(" ^ string_of_int n ^ ")"
+  | O_MULT e -> "O*(" ^ string_of_expr e ^ ")"
+  | I_MULT n -> "I*(" ^ string_of_int n ^ ")"
+
+type cnt_4 = tag list
 type state_4 = expr * cnt_4
 
 (* apply_4 : cnt_4 * int -> int 
@@ -209,31 +208,29 @@ type state_4 = expr * cnt_4
              (1) for all v, apply_3(c, v)  = apply_4(< c >, v) and 
              (2) eval_aux_3 (e, c) =  eval_aux_4 (e, < c >). 
    Proof : by induction on the structure of e and c. 
-*) 
-let rec apply_4 = function 
-   | ([],              v)  -> v 
-   | ((O_PLUS e2) :: cnt, v1) -> eval_aux_4(e2, (I_PLUS v1) :: cnt)
-   | ((O_SUBT e2) :: cnt, v1) -> eval_aux_4(e2, (I_SUBT v1) :: cnt)
-   | ((O_MULT e2) :: cnt, v1) -> eval_aux_4(e2, (I_MULT v1) :: cnt)
-   | ((I_PLUS v1) :: cnt, v2) -> apply_4(cnt, v1 + v2)
-   | ((I_SUBT v1) :: cnt, v2) -> apply_4(cnt, v1 - v2)
-   | ((I_MULT v1) :: cnt, v2) -> apply_4(cnt, v1 * v2)
+*)
+let rec apply_4 = function
+  | [], v -> v
+  | O_PLUS e2 :: cnt, v1 -> eval_aux_4 (e2, I_PLUS v1 :: cnt)
+  | O_SUBT e2 :: cnt, v1 -> eval_aux_4 (e2, I_SUBT v1 :: cnt)
+  | O_MULT e2 :: cnt, v1 -> eval_aux_4 (e2, I_MULT v1 :: cnt)
+  | I_PLUS v1 :: cnt, v2 -> apply_4 (cnt, v1 + v2)
+  | I_SUBT v1 :: cnt, v2 -> apply_4 (cnt, v1 - v2)
+  | I_MULT v1 :: cnt, v2 -> apply_4 (cnt, v1 * v2)
 
 (* eval_aux_4 : state_4 -> int 
-*) 
-and eval_aux_4 (e, cnt) = 
-   match e with 
-   | INT a        -> apply_4(cnt, a) 
-   | PLUS(e1, e2) -> eval_aux_4(e1, O_PLUS(e2) :: cnt) 
-   | SUBT(e1, e2) -> eval_aux_4(e1, O_SUBT(e2) :: cnt) 
-   | MULT(e1, e2) -> eval_aux_4(e1, O_MULT(e2) :: cnt) 
+*)
+and eval_aux_4 (e, cnt) =
+  match e with
+  | INT a -> apply_4 (cnt, a)
+  | PLUS (e1, e2) -> eval_aux_4 (e1, O_PLUS e2 :: cnt)
+  | SUBT (e1, e2) -> eval_aux_4 (e1, O_SUBT e2 :: cnt)
+  | MULT (e1, e2) -> eval_aux_4 (e1, O_MULT e2 :: cnt)
 
-(* eval_4 : expr -> int *) 
-let eval_4 e = eval_aux_4(e, []) 
+(* eval_4 : expr -> int *)
+let eval_4 e = eval_aux_4 (e, [])
 
-
-
-(******************************* eval_5 **************************************) 			 
+(******************************* eval_5 **************************************)
 
 (* Eliminate mutual tail recursion 
 
@@ -245,40 +242,36 @@ let eval_4 e = eval_aux_4(e, [])
    We can always combine such functions int a single recursive function 
    by "tagging" the two inputs. 
 
-*) 
-type state_5 = APPLY of cnt_4 * int  (* APPLY(c, m) represents a call apply_4(c, m) *) 
- 	     |  EVAL of cnt_4 * expr (* EVAL(c, e) represents a call eval_aux_4(e, c) *)
+*)
+type state_5 =
+  | APPLY of cnt_4 * int (* APPLY(c, m) represents a call apply_4(c, m) *)
+  | EVAL of cnt_4 * expr (* EVAL(c, e) represents a call eval_aux_4(e, c) *)
 
-let string_of_state5 n = function 
-  | EVAL(cnt, e) -> "step " 
-                    ^ (string_of_int n)
-		    ^ " (EVAL)"
-                    ^ "\ncnt = " ^ (string_of_list string_of_tag (List.rev cnt)) 
-                    ^ "\nexpr = " ^ (string_of_expr e)
-                    ^ "\n" 				      
-  | APPLY(cnt, m) -> "step " 
-                    ^ (string_of_int n)
-		    ^ " (APPLY)"
-                    ^ "\ncnt = " ^ (string_of_list string_of_tag (List.rev cnt)) 
-                    ^ "\nint = " ^ (string_of_int m)
-                    ^ "\n" 				     
+let string_of_state5 n = function
+  | EVAL (cnt, e) ->
+      "step " ^ string_of_int n ^ " (EVAL)" ^ "\ncnt = "
+      ^ string_of_list string_of_tag (List.rev cnt)
+      ^ "\nexpr = " ^ string_of_expr e ^ "\n"
+  | APPLY (cnt, m) ->
+      "step " ^ string_of_int n ^ " (APPLY)" ^ "\ncnt = "
+      ^ string_of_list string_of_tag (List.rev cnt)
+      ^ "\nint = " ^ string_of_int m ^ "\n"
 
-
-(* step : state_5 -> state_5 *) 
+(* step : state_5 -> state_5 *)
 
 let step_5 = function
-   | EVAL(cnt,              INT m) -> APPLY(cnt, m)
-   | EVAL(cnt,       PLUS(e1, e2)) -> EVAL((O_PLUS e2) :: cnt, e1)
-   | EVAL(cnt,       SUBT(e1, e2)) -> EVAL((O_SUBT e2) :: cnt, e1)
-   | EVAL(cnt,       MULT(e1, e2)) -> EVAL((O_MULT e2) :: cnt, e1)
-   | APPLY((O_PLUS e2) :: cnt, v1) -> EVAL((I_PLUS v1) :: cnt, e2)
-   | APPLY((O_SUBT e2) :: cnt, v1) -> EVAL((I_SUBT v1) :: cnt, e2)
-   | APPLY((O_MULT e2) :: cnt, v1) -> EVAL((I_MULT v1) :: cnt, e2)
-   | APPLY((I_PLUS v1) :: cnt, v2) -> APPLY(cnt, v1 + v2)
-   | APPLY((I_SUBT v1) :: cnt, v2) -> APPLY(cnt, v1 - v2)
-   | APPLY((I_MULT v1) :: cnt, v2) -> APPLY(cnt, v1 * v2)
-   | APPLY([],                  v) -> APPLY([],        v)
-				      
+  | EVAL (cnt, INT m) -> APPLY (cnt, m)
+  | EVAL (cnt, PLUS (e1, e2)) -> EVAL (O_PLUS e2 :: cnt, e1)
+  | EVAL (cnt, SUBT (e1, e2)) -> EVAL (O_SUBT e2 :: cnt, e1)
+  | EVAL (cnt, MULT (e1, e2)) -> EVAL (O_MULT e2 :: cnt, e1)
+  | APPLY (O_PLUS e2 :: cnt, v1) -> EVAL (I_PLUS v1 :: cnt, e2)
+  | APPLY (O_SUBT e2 :: cnt, v1) -> EVAL (I_SUBT v1 :: cnt, e2)
+  | APPLY (O_MULT e2 :: cnt, v1) -> EVAL (I_MULT v1 :: cnt, e2)
+  | APPLY (I_PLUS v1 :: cnt, v2) -> APPLY (cnt, v1 + v2)
+  | APPLY (I_SUBT v1 :: cnt, v2) -> APPLY (cnt, v1 - v2)
+  | APPLY (I_MULT v1 :: cnt, v2) -> APPLY (cnt, v1 * v2)
+  | APPLY ([], v) -> APPLY ([], v)
+
 (* driver : state_5 -> int 
    This is clearly TAIL RECURSIVE! 
 
@@ -287,18 +280,20 @@ let step_5 = function
       driver_5 (EVAL(c, e))  = eval_aux_4 (e, c)
    Proof : induction on e and c. 
 
-*) 
-let rec driver_5 n state = 
-    let _ = if !verbose then print_string(string_of_state5 n state) else () in
-    match state with   
-    | APPLY([], v) -> v
-    | _            -> driver_5 (n+1) (step_5 state) 
+*)
+let rec driver_5 n state =
+  let _ =
+    if !verbose then
+      print_string (string_of_state5 n state)
+    else
+      ()
+  in
+  match state with APPLY ([], v) -> v | _ -> driver_5 (n + 1) (step_5 state)
 
-(* eval_5 : expr -> int *) 
-let eval_5 e = driver_5 1 (EVAL([], e)) 
+(* eval_5 : expr -> int *)
+let eval_5 e = driver_5 1 (EVAL ([], e))
 
-
-(******************************* eval_6 **************************************)  
+(******************************* eval_6 **************************************)
 
 (* 
   Now for a tricky part! 
@@ -307,17 +302,12 @@ let eval_5 e = driver_5 1 (EVAL([], e))
   two distinct stacks --- one for "directives" (expressions and instructions) 
   and the other for integer values.  Call the first the "directive stack" 
   and the second the "value stack". 
-*) 
+*)
 
-type directive = 
-  | E of expr 
-  | DO_PLUS 
-  | DO_SUBT
-  | DO_MULT 
-
-type directive_stack = directive list 
-type value_stack     = int list 
-type state_6         = directive_stack * value_stack
+type directive = E of expr | DO_PLUS | DO_SUBT | DO_MULT
+type directive_stack = directive list
+type value_stack = int list
+type state_6 = directive_stack * value_stack
 
 (* 
    state_6 states have the form (DS, VS), where DS is a directive stack 
@@ -350,41 +340,44 @@ type state_6         = directive_stack * value_stack
    VS((O_OP e) :: c) = VS(c) 
 
    Proof of Claim 6.1. Look at each step_5 step and do a case analysis ... 
-*) 
-					   
+*)
 
-let string_of_directive = function 
-  | E e     -> string_of_expr e
-  | DO_PLUS -> "DO+" 
-  | DO_SUBT -> "DO-" 
-  | DO_MULT -> "DO*" 
+let string_of_directive = function
+  | E e -> string_of_expr e
+  | DO_PLUS -> "DO+"
+  | DO_SUBT -> "DO-"
+  | DO_MULT -> "DO*"
 
-let string_of_state6 n = function 
-  | (ds, vs) -> "state " 
-                 ^ (string_of_int n) 
-                 ^ "\nDS = " ^ (string_of_list string_of_directive (List.rev ds)) 
-                 ^ "\nVS = " ^ (string_of_list string_of_int (List.rev vs))
-                 ^ "\n" 				 
+let string_of_state6 n = function
+  | ds, vs ->
+      "state " ^ string_of_int n ^ "\nDS = "
+      ^ string_of_list string_of_directive (List.rev ds)
+      ^ "\nVS = "
+      ^ string_of_list string_of_int (List.rev vs)
+      ^ "\n"
 
-(* step_6 : state_6 -> state_6 *) 
-let step_6 = function 
-   | (E(INT v) :: ds,            vs) -> (ds, v :: vs)
-   | (E(PLUS(e1, e2)) :: ds,     vs) -> ((E e1) :: (E e2) :: DO_PLUS :: ds, vs)
-   | (E(SUBT(e1, e2)) :: ds,     vs) -> ((E e1) :: (E e2) :: DO_SUBT :: ds, vs) 
-   | (E(MULT(e1, e2)) :: ds,     vs) -> ((E e1) :: (E e2) :: DO_MULT :: ds, vs) 
-   | (DO_PLUS :: ds, v2 :: v1 :: vs) -> (ds, (v1 + v2) :: vs) 
-   | (DO_SUBT :: ds, v2 :: v1 :: vs) -> (ds, (v1 - v2) :: vs) 
-   | (DO_MULT :: ds, v2 :: v1 :: vs) -> (ds, (v1 * v2) :: vs) 
-   | _ -> failwith "eval : runtime error!"        
+(* step_6 : state_6 -> state_6 *)
+let step_6 = function
+  | E (INT v) :: ds, vs -> (ds, v :: vs)
+  | E (PLUS (e1, e2)) :: ds, vs -> (E e1 :: E e2 :: DO_PLUS :: ds, vs)
+  | E (SUBT (e1, e2)) :: ds, vs -> (E e1 :: E e2 :: DO_SUBT :: ds, vs)
+  | E (MULT (e1, e2)) :: ds, vs -> (E e1 :: E e2 :: DO_MULT :: ds, vs)
+  | DO_PLUS :: ds, v2 :: v1 :: vs -> (ds, (v1 + v2) :: vs)
+  | DO_SUBT :: ds, v2 :: v1 :: vs -> (ds, (v1 - v2) :: vs)
+  | DO_MULT :: ds, v2 :: v1 :: vs -> (ds, (v1 * v2) :: vs)
+  | _ -> failwith "eval : runtime error!"
 
-(* driver_6 : state_6 -> int *) 
-let rec driver_6 n state = 
-    let _ = if !verbose then print_string(string_of_state6 n state) else () in 
-    match state with 
-    | ([], [v]) -> v
-    | _         -> driver_6 (n+1) (step_6 state) 
+(* driver_6 : state_6 -> int *)
+let rec driver_6 n state =
+  let _ =
+    if !verbose then
+      print_string (string_of_state6 n state)
+    else
+      ()
+  in
+  match state with [], [ v ] -> v | _ -> driver_6 (n + 1) (step_6 state)
 
-let eval_6 e = driver_6 1 ([E e], []) 
+let eval_6 e = driver_6 1 ([ E e ], [])
 
 (*  side-by-side traces 
 
@@ -540,9 +533,9 @@ cnt = []                             | DS = []
 int = 15                             | VS = [15]
 ---------------------------------------------------------------------------
 
-*) 
-			
-(******************************* eval_7 **************************************) 			 			
+*)
+
+(******************************* eval_7 **************************************)
 (* 
    Another tricky part!  
 
@@ -557,59 +550,54 @@ int = 15                             | VS = [15]
    we do this instead at "compile time" rather than at "runtime"? 
    In other words, let's re-factor eval_6 so and define a function 
    "compile" and eval_7 so that  eval_6(e) = eval_7(compile(e)). 
-*) 
-type instr = 
-  | Ipush of int 
-  | Iplus  
-  | Isubt  
-  | Imult  
-
-type code = instr list 
-
-type state_7 = code * value_stack 
+*)
+type instr = Ipush of int | Iplus | Isubt | Imult
+type code = instr list
+type state_7 = code * value_stack
 
 (* compile : expr -> code 
  
    Note similarity with the lines of step_6 mentioned above! 
-*) 
-let rec compile = function 
-   | INT a          -> [Ipush a] 
-   | PLUS(e1, e2)   -> (compile e1) @ (compile e2) @ [Iplus] 
-   | SUBT(e1, e2)   -> (compile e1) @ (compile e2) @ [Isubt] 
-   | MULT(e1, e2)   -> (compile e1) @ (compile e2) @ [Imult] 
+*)
+let rec compile = function
+  | INT a -> [ Ipush a ]
+  | PLUS (e1, e2) -> compile e1 @ compile e2 @ [ Iplus ]
+  | SUBT (e1, e2) -> compile e1 @ compile e2 @ [ Isubt ]
+  | MULT (e1, e2) -> compile e1 @ compile e2 @ [ Imult ]
 
-(* step_7 : state_7 -> state_7 *) 
-let step_7 = function 
-   | (Ipush v :: is,      vs) ->  (is, v :: vs)
-   | (Iplus :: is, v2::v1::vs) -> (is, (v1 + v2) :: vs)
-   | (Isubt :: is, v2::v1::vs) -> (is, (v1 - v2) :: vs)
-   | (Imult :: is, v2::v1::vs) -> (is, (v1 * v2) :: vs)
-   | _ -> failwith "eval : runtime error!"        
+(* step_7 : state_7 -> state_7 *)
+let step_7 = function
+  | Ipush v :: is, vs -> (is, v :: vs)
+  | Iplus :: is, v2 :: v1 :: vs -> (is, (v1 + v2) :: vs)
+  | Isubt :: is, v2 :: v1 :: vs -> (is, (v1 - v2) :: vs)
+  | Imult :: is, v2 :: v1 :: vs -> (is, (v1 * v2) :: vs)
+  | _ -> failwith "eval : runtime error!"
 
-let rec string_of_instr = function 
-  | Ipush a -> "push " ^ (string_of_int a)
+let rec string_of_instr = function
+  | Ipush a -> "push " ^ string_of_int a
   | Iplus -> "add"
   | Isubt -> "sub"
   | Imult -> "mul"
 
+let string_of_state7 n = function
+  | is, vs ->
+      "state " ^ string_of_int n ^ "\nIS = "
+      ^ string_of_list string_of_instr (List.rev is)
+      ^ "\nVS = "
+      ^ string_of_list string_of_int (List.rev vs)
+      ^ "\n"
 
-let string_of_state7 n = function 
-  | (is, vs) -> "state " 
-                 ^ (string_of_int n) 
-                 ^ "\nIS = " ^ (string_of_list string_of_instr (List.rev is)) 
-                 ^ "\nVS = " ^ (string_of_list string_of_int (List.rev vs))
-                 ^ "\n" 
-
-
-(* driver_7 : state_7 -> int *) 
+(* driver_7 : state_7 -> int *)
 let rec driver_7 n state =
-    let _ = if !verbose then print_string(string_of_state7 n state) else () in 
-    match state with 
-    | ([], [v]) -> v
-    | _ -> driver_7 (n+1) (step_7 state)
+  let _ =
+    if !verbose then
+      print_string (string_of_state7 n state)
+    else
+      ()
+  in
+  match state with [], [ v ] -> v | _ -> driver_7 (n + 1) (step_7 state)
 
-let eval_7 e = driver_7 1 (compile e, []) 
-
+let eval_7 e = driver_7 1 (compile e, [])
 
 (* 			
 
@@ -745,8 +733,7 @@ state 14                                 | state 10
 DS = []                                  | IS = []
 VS = [15]                                | VS = [15]
 ---------------------------------------------------------------------------
- *) 
-
+ *)
 
 (* 
    What can we conclude?
@@ -757,4 +744,4 @@ VS = [15]                                | VS = [15]
    into a compiler + a stack machine. 
   
 
-*) 			
+*)

--- a/basic_transformations/tail.ml
+++ b/basic_transformations/tail.ml
@@ -3,23 +3,21 @@ Compiler Construction 2016
 Computer Laboratory 
 University of Cambridge 
 Timothy G. Griffin (tgg22@cam.ac.uk) 
-*****************************************) 
-
+*****************************************)
 
 (* gcd : int * int -> int 
 
    This is a tail-recursive function. 
-*) 
-let rec gcd(m, n) = 
-    if m = n 
-    then m 
-    else if m < n 
-         then gcd(m, n - m)
-         else gcd(m - n, n)
+*)
+let rec gcd (m, n) =
+  if m = n then
+    m
+  else if m < n then
+    gcd (m, n - m)
+  else
+    gcd (m - n, n)
 
-let l1 = List.map gcd [(24, 638); (17, 289); (31, 1889)] 
-
-
+let l1 = List.map gcd [ (24, 638); (17, 289); (31, 1889) ]
 
 (* gcd_iter : int * int -> int 
 
@@ -27,35 +25,35 @@ let l1 = List.map gcd [(24, 638); (17, 289); (31, 1889)]
    The OCaml compiler will do something similar 
    to gcd (above), but on a lower-level intermediate 
    representation. 
-*) 
+*)
 
-let gcd_iter (m, n) = 
-    let rm = ref m 
-    in let rn = ref n 
-    in let result = ref 0 
-    in let not_done = ref true 
-    in let _ = while !not_done 
-               do 
-                 if !rm = !rn 
-                 then (not_done := false; result := !rm) 
-                 else if !rm < !rn 
-                      then rn := !rn - !rm 
-                      else rm := !rm - !rn
-               done 
-    in !result           
-    
-let l2 = List.map gcd_iter [(24, 638); (17, 289); (31, 1889)] 
+let gcd_iter (m, n) =
+  let rm = ref m in
+  let rn = ref n in
+  let result = ref 0 in
+  let not_done = ref true in
+  let _ =
+    while !not_done do
+      if !rm = !rn then (
+        not_done := false;
+        result := !rm)
+      else if !rm < !rn then
+        rn := !rn - !rm
+      else
+        rm := !rm - !rn
+    done
+  in
+  !result
 
+let l2 = List.map gcd_iter [ (24, 638); (17, 289); (31, 1889) ]
 
-(* Here is the mother of all tail-recurive functions *) 
-let rec my_while (test, body) () = 
-        if test() then my_while(test, body) (body())
+(* Here is the mother of all tail-recurive functions *)
+let rec my_while (test, body) () =
+  if test () then
+    my_while (test, body) (body ())
 
-(* we can eliminate recursion with iteration! *) 
-let my_while_iter (test, body) () = while test() do body() done 
-        
-        
-
-
-
-
+(* we can eliminate recursion with iteration! *)
+let my_while_iter (test, body) () =
+  while test () do
+    body ()
+  done

--- a/slang/ast.ml
+++ b/slang/ast.ml
@@ -1,36 +1,32 @@
-
 type var = string
-
 type oper = ADD | MUL | DIV | SUB | LT | AND | OR | EQB | EQI
-
 type unary_oper = NEG | NOT | READ
 
 type expr =
-       | Unit
-       | Var of var
-       | Integer of int
-       | Boolean of bool
-       | UnaryOp of unary_oper * expr
-       | Op of expr * oper * expr
-       | If of expr * expr * expr
-       | Pair of expr * expr
-       | Fst of expr
-       | Snd of expr
-       | Inl of expr
-       | Inr of expr
-       | Case of expr * lambda * lambda
-       | While of expr * expr
-       | Seq of expr list
-       | Ref of expr
-       | Deref of expr
-       | Assign of expr * expr
-       | Lambda of lambda
-       | App of expr * expr
-       | LetFun of var * lambda * expr
-       | LetRecFun of var * lambda * expr
+  | Unit
+  | Var of var
+  | Integer of int
+  | Boolean of bool
+  | UnaryOp of unary_oper * expr
+  | Op of expr * oper * expr
+  | If of expr * expr * expr
+  | Pair of expr * expr
+  | Fst of expr
+  | Snd of expr
+  | Inl of expr
+  | Inr of expr
+  | Case of expr * lambda * lambda
+  | While of expr * expr
+  | Seq of expr list
+  | Ref of expr
+  | Deref of expr
+  | Assign of expr * expr
+  | Lambda of lambda
+  | App of expr * expr
+  | LetFun of var * lambda * expr
+  | LetRecFun of var * lambda * expr
 
 and lambda = var * expr
-
 
 open Format
 
@@ -40,137 +36,130 @@ open Format
    http://caml.inria.fr/pub/docs/manual-ocaml/libref/Format.html
 *)
 
-let pp_uop = function
-  | NEG -> "-"
-  | NOT -> "~"
-  | READ -> "read"
-
+let pp_uop = function NEG -> "-" | NOT -> "~" | READ -> "read"
 
 let pp_bop = function
   | ADD -> "+"
-  | MUL  -> "*"
-  | DIV  -> "/"
+  | MUL -> "*"
+  | DIV -> "/"
   | SUB -> "-"
-  | LT   -> "<"
-  | EQI   -> "eqi"
-  | EQB   -> "eqb"
-  | AND   -> "&&"
-  | OR   -> "||"
-
+  | LT -> "<"
+  | EQI -> "eqi"
+  | EQB -> "eqb"
+  | AND -> "&&"
+  | OR -> "||"
 
 let string_of_oper = pp_bop
 let string_of_unary_oper = pp_uop
-
 let fstring ppf s = fprintf ppf "%s" s
-
 let pp_unary ppf t = fstring ppf (pp_uop t)
-
 let pp_binary ppf t = fstring ppf (pp_bop t)
 
 let rec pp_expr ppf = function
-    | Unit              -> fstring ppf "()"
-    | Var x             -> fstring ppf x
-    | Integer n         -> fstring ppf (string_of_int n)
-    | Boolean b         -> fstring ppf (string_of_bool b)
-    | UnaryOp(op, e)    -> fprintf ppf "%a(%a)" pp_unary op pp_expr e
-    | Op(e1, op, e2)    -> fprintf ppf "(%a %a %a)" pp_expr e1  pp_binary op pp_expr e2
-    | If(e1, e2, e3)    -> fprintf ppf "@[if %a then %a else %a @]"
-                                      pp_expr e1 pp_expr e2 pp_expr e3
-    | Pair(e1, e2)      -> fprintf ppf "(%a, %a)" pp_expr e1 pp_expr e2
-    | Fst(e)            -> fprintf ppf "fst(%a)" pp_expr e
-    | Snd(e)            -> fprintf ppf "snd(%a)" pp_expr e
-    | Inl(e)            -> fprintf ppf "inl(%a)" pp_expr e
-    | Inr(e)            -> fprintf ppf "inr(%a)" pp_expr e
-    | Case(e, (x1, e1), (x2, e2)) ->
-        fprintf ppf "@[<2>case %a of@ | inl %a -> %a @ | inr %a -> %a end@]"
-                     pp_expr e fstring x1 pp_expr e1 fstring x2 pp_expr e2
-    | Lambda(x, e) ->
-         fprintf ppf "(fun %a -> %a)" fstring x pp_expr e
-    | App(e1, e2)       -> fprintf ppf "%a %a" pp_expr e1 pp_expr e2
+  | Unit -> fstring ppf "()"
+  | Var x -> fstring ppf x
+  | Integer n -> fstring ppf (string_of_int n)
+  | Boolean b -> fstring ppf (string_of_bool b)
+  | UnaryOp (op, e) -> fprintf ppf "%a(%a)" pp_unary op pp_expr e
+  | Op (e1, op, e2) ->
+      fprintf ppf "(%a %a %a)" pp_expr e1 pp_binary op pp_expr e2
+  | If (e1, e2, e3) ->
+      fprintf ppf "@[if %a then %a else %a @]" pp_expr e1 pp_expr e2 pp_expr e3
+  | Pair (e1, e2) -> fprintf ppf "(%a, %a)" pp_expr e1 pp_expr e2
+  | Fst e -> fprintf ppf "fst(%a)" pp_expr e
+  | Snd e -> fprintf ppf "snd(%a)" pp_expr e
+  | Inl e -> fprintf ppf "inl(%a)" pp_expr e
+  | Inr e -> fprintf ppf "inr(%a)" pp_expr e
+  | Case (e, (x1, e1), (x2, e2)) ->
+      fprintf ppf "@[<2>case %a of@ | inl %a -> %a @ | inr %a -> %a end@]"
+        pp_expr e fstring x1 pp_expr e1 fstring x2 pp_expr e2
+  | Lambda (x, e) -> fprintf ppf "(fun %a -> %a)" fstring x pp_expr e
+  | App (e1, e2) -> fprintf ppf "%a %a" pp_expr e1 pp_expr e2
+  | Seq el -> fprintf ppf "begin %a end" pp_expr_list el
+  | While (e1, e2) -> fprintf ppf "while %a do %a end" pp_expr e1 pp_expr e2
+  | Ref e -> fprintf ppf "ref(%a)" pp_expr e
+  | Deref e -> fprintf ppf "!(%a)" pp_expr e
+  | Assign (e1, e2) -> fprintf ppf "(%a := %a)" pp_expr e1 pp_expr e2
+  | LetFun (f, (x, e1), e2) ->
+      fprintf ppf "@[let %a(%a) =@ %a @ in %a @ end@]" fstring f fstring x
+        pp_expr e1 pp_expr e2
+  | LetRecFun (f, (x, e1), e2) ->
+      fprintf ppf "@[letrec %a(%a) =@ %a @ in %a @ end@]" fstring f fstring x
+        pp_expr e1 pp_expr e2
 
-    | Seq(el)           -> fprintf ppf "begin %a end" pp_expr_list el
-    | While(e1, e2)     -> fprintf ppf "while %a do %a end" pp_expr e1 pp_expr e2
-    | Ref(e)            -> fprintf ppf "ref(%a)" pp_expr e
-    | Deref(e)          -> fprintf ppf "!(%a)" pp_expr e
-    | Assign(e1, e2)    -> fprintf ppf "(%a := %a)" pp_expr e1 pp_expr e2
-    | LetFun(f, (x, e1), e2)     ->
-         fprintf ppf "@[let %a(%a) =@ %a @ in %a @ end@]"
-                     fstring f fstring x  pp_expr e1 pp_expr e2
-    | LetRecFun(f, (x, e1), e2)  ->
-         fprintf ppf "@[letrec %a(%a) =@ %a @ in %a @ end@]"
-                     fstring f fstring x  pp_expr e1 pp_expr e2
 and pp_expr_list ppf = function
   | [] -> ()
-  | [e] -> pp_expr ppf e
-  |  e:: rest -> fprintf ppf "%a; %a" pp_expr e pp_expr_list rest
-
+  | [ e ] -> pp_expr ppf e
+  | e :: rest -> fprintf ppf "%a; %a" pp_expr e pp_expr_list rest
 
 let print_expr e =
-    let _ = pp_expr std_formatter e
-    in print_flush ()
+  let _ = pp_expr std_formatter e in
+  print_flush ()
 
 let eprint_expr e =
-    let _ = pp_expr err_formatter e
-    in pp_print_flush err_formatter ()
-
-
+  let _ = pp_expr err_formatter e in
+  pp_print_flush err_formatter ()
 
 (* useful for debugging *)
 
-let string_of_uop = function
-  | NEG -> "NEG"
-  | NOT -> "NOT"
-  | READ -> "READ"
+let string_of_uop = function NEG -> "NEG" | NOT -> "NOT" | READ -> "READ"
 
 let string_of_bop = function
   | ADD -> "ADD"
-  | MUL  -> "MUL"
-  | DIV  -> "DIV"
+  | MUL -> "MUL"
+  | DIV -> "DIV"
   | SUB -> "SUB"
-  | LT   -> "LT"
-  | EQI   -> "EQI"
-  | EQB   -> "EQB"
-  | AND   -> "AND"
-  | OR   -> "OR"
+  | LT -> "LT"
+  | EQI -> "EQI"
+  | EQB -> "EQB"
+  | AND -> "AND"
+  | OR -> "OR"
 
 let mk_con con l =
-    let rec aux carry = function
-      | [] -> carry ^ ")"
-      | [s] -> carry ^ s ^ ")"
-      | s::rest -> aux (carry ^ s ^ ", ") rest
-    in aux (con ^ "(") l
+  let rec aux carry = function
+    | [] -> carry ^ ")"
+    | [ s ] -> carry ^ s ^ ")"
+    | s :: rest -> aux (carry ^ s ^ ", ") rest
+  in
+  aux (con ^ "(") l
 
 let rec string_of_expr = function
-    | Unit            -> "Unit"
-    | Var x            -> mk_con "Var" [x]
-    | Integer n        -> mk_con "Integer" [string_of_int n]
-    | Boolean b        -> mk_con "Boolean" [string_of_bool b]
-    | UnaryOp(op, e)   -> mk_con "UnaryOp" [string_of_uop op; string_of_expr e]
-    | Op(e1, op, e2)   -> mk_con "Op" [string_of_expr e1; string_of_bop op; string_of_expr e2]
-    | If(e1, e2, e3)   -> mk_con "If" [string_of_expr e1; string_of_expr e2; string_of_expr e3]
-    | Pair(e1, e2)     -> mk_con "Pair" [string_of_expr e1; string_of_expr e2]
-    | Fst e            -> mk_con "Fst" [string_of_expr e]
-    | Snd e            -> mk_con "Snd" [string_of_expr e]
-    | Inl e            -> mk_con "Inl" [string_of_expr e]
-    | Inr e            -> mk_con "Inr" [string_of_expr e]
-    | Lambda(x, e)     -> mk_con "Lambda" [x; string_of_expr e]
-    | App(e1, e2)      -> mk_con "App" [string_of_expr e1; string_of_expr e2]
-    | Seq el           -> mk_con "Seq" [string_of_expr_list el]
-    | While(e1, e2)   -> mk_con "While" [string_of_expr e1; string_of_expr e2]
-    | Ref e            -> mk_con "Ref" [string_of_expr e]
-    | Deref e          -> mk_con "Deref" [string_of_expr e]
-    | Assign (e1, e2)  -> mk_con "Assign" [string_of_expr e1; string_of_expr e2]
-    | LetFun(f, (x, e1), e2)      ->
-          mk_con "LetFun" [f; mk_con "" [x; string_of_expr e1]; string_of_expr e2]
-    | LetRecFun(f, (x, e1), e2)   ->
-          mk_con "LetRecFun" [f; mk_con "" [x; string_of_expr e1]; string_of_expr e2]
-    | Case(e, (x1, e1), (x2, e2)) ->
-          mk_con "Case" [
-              string_of_expr e;
-	      mk_con "" [x1; string_of_expr e1];
-	      mk_con "" [x2; string_of_expr e2]]
+  | Unit -> "Unit"
+  | Var x -> mk_con "Var" [ x ]
+  | Integer n -> mk_con "Integer" [ string_of_int n ]
+  | Boolean b -> mk_con "Boolean" [ string_of_bool b ]
+  | UnaryOp (op, e) -> mk_con "UnaryOp" [ string_of_uop op; string_of_expr e ]
+  | Op (e1, op, e2) ->
+      mk_con "Op" [ string_of_expr e1; string_of_bop op; string_of_expr e2 ]
+  | If (e1, e2, e3) ->
+      mk_con "If" [ string_of_expr e1; string_of_expr e2; string_of_expr e3 ]
+  | Pair (e1, e2) -> mk_con "Pair" [ string_of_expr e1; string_of_expr e2 ]
+  | Fst e -> mk_con "Fst" [ string_of_expr e ]
+  | Snd e -> mk_con "Snd" [ string_of_expr e ]
+  | Inl e -> mk_con "Inl" [ string_of_expr e ]
+  | Inr e -> mk_con "Inr" [ string_of_expr e ]
+  | Lambda (x, e) -> mk_con "Lambda" [ x; string_of_expr e ]
+  | App (e1, e2) -> mk_con "App" [ string_of_expr e1; string_of_expr e2 ]
+  | Seq el -> mk_con "Seq" [ string_of_expr_list el ]
+  | While (e1, e2) -> mk_con "While" [ string_of_expr e1; string_of_expr e2 ]
+  | Ref e -> mk_con "Ref" [ string_of_expr e ]
+  | Deref e -> mk_con "Deref" [ string_of_expr e ]
+  | Assign (e1, e2) -> mk_con "Assign" [ string_of_expr e1; string_of_expr e2 ]
+  | LetFun (f, (x, e1), e2) ->
+      mk_con "LetFun"
+        [ f; mk_con "" [ x; string_of_expr e1 ]; string_of_expr e2 ]
+  | LetRecFun (f, (x, e1), e2) ->
+      mk_con "LetRecFun"
+        [ f; mk_con "" [ x; string_of_expr e1 ]; string_of_expr e2 ]
+  | Case (e, (x1, e1), (x2, e2)) ->
+      mk_con "Case"
+        [
+          string_of_expr e;
+          mk_con "" [ x1; string_of_expr e1 ];
+          mk_con "" [ x2; string_of_expr e2 ];
+        ]
 
 and string_of_expr_list = function
   | [] -> ""
-  | [e] -> string_of_expr e
-  |  e:: rest -> string_of_expr e ^ "; " ^ string_of_expr_list rest
+  | [ e ] -> string_of_expr e
+  | e :: rest -> string_of_expr e ^ "; " ^ string_of_expr_list rest

--- a/slang/ast.mli
+++ b/slang/ast.mli
@@ -1,35 +1,30 @@
-
 type var = string
-
 type oper = ADD | MUL | DIV | SUB | LT | AND | OR | EQB | EQI
-
 type unary_oper = NEG | NOT | READ
 
 type expr =
-       | Unit
-       | Var of var
-       | Integer of int
-       | Boolean of bool
-       | UnaryOp of unary_oper * expr
-       | Op of expr * oper * expr
-       | If of expr * expr * expr
-       | Pair of expr * expr
-       | Fst of expr
-       | Snd of expr
-       | Inl of expr
-       | Inr of expr
-       | Case of expr * lambda * lambda
-
-       | While of expr * expr
-       | Seq of expr list
-       | Ref of expr
-       | Deref of expr
-       | Assign of expr * expr
-
-       | Lambda of lambda
-       | App of expr * expr
-       | LetFun of var * lambda * expr
-       | LetRecFun of var * lambda * expr
+  | Unit
+  | Var of var
+  | Integer of int
+  | Boolean of bool
+  | UnaryOp of unary_oper * expr
+  | Op of expr * oper * expr
+  | If of expr * expr * expr
+  | Pair of expr * expr
+  | Fst of expr
+  | Snd of expr
+  | Inl of expr
+  | Inr of expr
+  | Case of expr * lambda * lambda
+  | While of expr * expr
+  | Seq of expr list
+  | Ref of expr
+  | Deref of expr
+  | Assign of expr * expr
+  | Lambda of lambda
+  | App of expr * expr
+  | LetFun of var * lambda * expr
+  | LetRecFun of var * lambda * expr
 
 and lambda = Past.var * expr
 

--- a/slang/dune
+++ b/slang/dune
@@ -1,30 +1,16 @@
 (ocamlyacc parser)
+
 (ocamllex lexer)
+
 (library
-  (name slanglib)
-  (modules
-    Front_end
-    Interp_0
-    Interp_1
-    Interp_2
-    Interp_3
-    Jargon
-    Jargon_to_x86
-    Ast
-    Past
-    Errors
-    Option
-    Free_vars
-    Pptree
-    Parser
-    Lexer
-    Static
-    Tests
-    Past_to_ast)
-  (preprocess (pps ppx_deriving_yojson))
-)
+ (name slanglib)
+ (modules Front_end Interp_0 Interp_1 Interp_2 Interp_3 Jargon Jargon_to_x86
+   Ast Past Errors Option Free_vars Pptree Parser Lexer Static Tests
+   Past_to_ast)
+ (preprocess
+  (pps ppx_deriving_yojson)))
 
 (executable
-  (name slang)
-  (libraries slanglib)
-  (modules slang))
+ (name slang)
+ (libraries slanglib)
+ (modules slang))

--- a/slang/errors.ml
+++ b/slang/errors.ml
@@ -1,4 +1,4 @@
-exception Error of string 
+exception Error of string
 
-let complain s = raise (Error s) 
+let complain s = raise (Error s)
 let complainf fmt = Format.kasprintf complain fmt

--- a/slang/errors.mli
+++ b/slang/errors.mli
@@ -2,4 +2,3 @@ exception Error of string
 
 val complain : string -> 'a
 val complainf : ('a, Format.formatter, unit, 'b) format4 -> 'a
-

--- a/slang/free_vars.ml
+++ b/slang/free_vars.ml
@@ -1,36 +1,43 @@
 open Ast
 
 let rec inlist x = function
-  | [] ->  false
-  | y :: rest -> if x = y then true else inlist x rest
+  | [] -> false
+  | y :: rest ->
+      if x = y then
+        true
+      else
+        inlist x rest
 
 (* free_vars (bvars, e) returns a
     list, with no duplicates, of all free variables
     of e that are not in the list bvars.
 *)
-let free_vars(bvars, exp) =
-    let rec aux bound free = function
-    | Var x              -> if  inlist x bound ||   inlist x free then free else x :: free
-    | UnaryOp(_, e)      -> aux bound free e
-    | Op(e1, _, e2)      -> aux bound  (aux bound free e1) e2
-    | If(e1, e2, e3)     -> aux bound (aux bound  (aux bound free e1) e2) e3
-    | Pair(e1, e2)       -> aux bound  (aux bound free e1) e2
-    | App(e1, e2)        -> aux bound  (aux bound free e1) e2
-    | Fst e              -> aux bound free e
-    | Snd e              -> aux bound free e
-    | Inl e              -> aux bound free e
-    | Inr e              -> aux bound free e
-    | Lambda l           -> lambda bound free l
-    | Case(e, l1, l2)    -> lambda bound (lambda bound (aux bound free e) l1) l2
-    | LetFun(f, l, e)    -> aux (f :: bound) (lambda bound free l) e
-    | LetRecFun(f, l, e) -> aux (f :: bound) (lambda  (f :: bound) free l) e
-    | Ref e              -> aux bound free e
-    | Deref e            -> aux bound free e
-    | Assign(e1, e2)     -> aux bound (aux bound free e1) e2
-    | While(e1, e2)      -> aux bound (aux bound free e1) e2
-    | Seq []             -> free
-    | Seq(e :: rest)     -> aux bound (aux bound free e) (Seq rest)
-    | _                  -> free
-    and lambda bound free (x, e) = aux (x :: bound) free e
-   in aux bvars [] exp
-
+let free_vars (bvars, exp) =
+  let rec aux bound free = function
+    | Var x ->
+        if inlist x bound || inlist x free then
+          free
+        else
+          x :: free
+    | UnaryOp (_, e) -> aux bound free e
+    | Op (e1, _, e2) -> aux bound (aux bound free e1) e2
+    | If (e1, e2, e3) -> aux bound (aux bound (aux bound free e1) e2) e3
+    | Pair (e1, e2) -> aux bound (aux bound free e1) e2
+    | App (e1, e2) -> aux bound (aux bound free e1) e2
+    | Fst e -> aux bound free e
+    | Snd e -> aux bound free e
+    | Inl e -> aux bound free e
+    | Inr e -> aux bound free e
+    | Lambda l -> lambda bound free l
+    | Case (e, l1, l2) -> lambda bound (lambda bound (aux bound free e) l1) l2
+    | LetFun (f, l, e) -> aux (f :: bound) (lambda bound free l) e
+    | LetRecFun (f, l, e) -> aux (f :: bound) (lambda (f :: bound) free l) e
+    | Ref e -> aux bound free e
+    | Deref e -> aux bound free e
+    | Assign (e1, e2) -> aux bound (aux bound free e1) e2
+    | While (e1, e2) -> aux bound (aux bound free e1) e2
+    | Seq [] -> free
+    | Seq (e :: rest) -> aux bound (aux bound free e) (Seq rest)
+    | _ -> free
+  and lambda bound free (x, e) = aux (x :: bound) free e in
+  aux bvars [] exp

--- a/slang/free_vars.mli
+++ b/slang/free_vars.mli
@@ -1,5 +1,3 @@
-
-
 (*
      free_vars (bvars, e) returns a list of the
      free vars of e that are not contained in bvars.

--- a/slang/front_end.ml
+++ b/slang/front_end.ml
@@ -1,52 +1,73 @@
-open Lexing 
+open Lexing
 
-let error file action s = 
-    Errors.complain ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n") 
+let error file action s =
+  Errors.complain ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n")
 
-let peek m e pp = if Option.verbose_front then print_string (m ^ ":\n" ^ (if Option.verbose_tree then Pptree.pp_no_bracket else (fun x -> x)) (pp e)  ^ "\n") else () 
+let peek m e pp =
+  if Option.verbose_front then
+    print_string
+      (m ^ ":\n"
+      ^ (if Option.verbose_tree then
+           Pptree.pp_no_bracket
+         else
+           fun x -> x)
+          (pp e)
+      ^ "\n")
+  else
+    ()
 
-let parse_error file lexbuf = 
-    let pos = lexbuf.lex_curr_p in 
-    let line = string_of_int (pos.pos_lnum) in 
-    let pos = string_of_int ((pos.pos_cnum - pos.pos_bol) + 1) in 
-        error file "parsing" ("at line " ^ line ^ " position " ^ pos)
+let parse_error file lexbuf =
+  let pos = lexbuf.lex_curr_p in
+  let line = string_of_int pos.pos_lnum in
+  let pos = string_of_int (pos.pos_cnum - pos.pos_bol + 1) in
+  error file "parsing" ("at line " ^ line ^ " position " ^ pos)
 
- (* initialize lexer *) 
+(* initialize lexer *)
 let init_lexbuf file =
-   let in_chan = try open_in file 
-                 with _ -> error file "initialize lexer" ("can't open file " ^ file) 
-  in let lexbuf = from_channel in_chan 
-  in let _ = lexbuf.lex_curr_p <- { pos_fname = file; pos_lnum = 1; pos_bol = 0; pos_cnum = 0; }
-  in (file, lexbuf) 
+  let in_chan =
+    try open_in file
+    with _ -> error file "initialize lexer" ("can't open file " ^ file)
+  in
+  let lexbuf = from_channel in_chan in
+  let _ =
+    lexbuf.lex_curr_p <-
+      { pos_fname = file; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+  in
+  (file, lexbuf)
 
- (* parse input file *) 
-let parse (file, lexbuf) = 
-    let e = try Parser.start Lexer.token lexbuf 
-            with Parsing.Parse_error -> parse_error file lexbuf 
-    in let _ = peek "Parsed result" e Past.string_of_expr 
-    in (file, e) 
+(* parse input file *)
+let parse (file, lexbuf) =
+  let e =
+    try Parser.start Lexer.token lexbuf
+    with Parsing.Parse_error -> parse_error file lexbuf
+  in
+  let _ = peek "Parsed result" e Past.string_of_expr in
+  (file, e)
 
- (* perform static checks *) 
-let check (file, e) = 
-    let e', _ = try Static.infer [] e 
-                with Errors.Error s -> error file "static check" s 
-    in let _ = peek "After static checks" e' Past.string_of_expr 
-    in e'
+(* perform static checks *)
+let check (file, e) =
+  let e', _ =
+    try Static.infer [] e with Errors.Error s -> error file "static check" s
+  in
+  let _ = peek "After static checks" e' Past.string_of_expr in
+  e'
 
-(* translate from Past.expr to Ast.expr *) 
+(* translate from Past.expr to Ast.expr *)
 let translate e =
-    let e' = Past_to_ast.translate_expr e
-    in let _ = peek "After translation" e' Ast.string_of_expr
-    in e'
+  let e' = Past_to_ast.translate_expr e in
+  let _ = peek "After translation" e' Ast.string_of_expr in
+  e'
 
 (* the front end *)
 let front_end file = translate (check (parse (init_lexbuf file)))
 
 (* front end reading directly from string *)
 let initstrbuf str =
-  let lexbuf = from_string str
-  in let _ = lexbuf.lex_curr_p <- { pos_fname = "input"; pos_lnum = 1; pos_bol = 0; pos_cnum = 0; }
-  in ("input", lexbuf)
+  let lexbuf = from_string str in
+  let _ =
+    lexbuf.lex_curr_p <-
+      { pos_fname = "input"; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+  in
+  ("input", lexbuf)
 
 let front_end_from_string str = translate (check (parse (initstrbuf str)))
-

--- a/slang/front_end.mli
+++ b/slang/front_end.mli
@@ -1,3 +1,2 @@
 val front_end : string -> Ast.expr
-
 val front_end_from_string : string -> Ast.expr

--- a/slang/interp_0.ml
+++ b/slang/interp_0.ml
@@ -34,144 +34,178 @@ type address = int
 type store = address -> value
 
 and value =
-     | REF of address
-     | INT of int
-     | BOOL of bool
-     | UNIT
-     | PAIR of value * value
-     | INL of value
-     | INR of value
-     | FUN of ((value * store) -> (value * store))
+  | REF of address
+  | INT of int
+  | BOOL of bool
+  | UNIT
+  | PAIR of value * value
+  | INL of value
+  | INR of value
+  | FUN of (value * store -> value * store)
 
 type env = var -> value
 
 (* auxiliary functions *)
 
 let rec string_of_value = function
-     | REF a -> "address(" ^ (string_of_int a) ^ ")"
-     | BOOL b -> string_of_bool b
-     | INT n -> string_of_int n
-     | UNIT -> "()"
-     | PAIR(v1, v2) -> "(" ^ (string_of_value v1) ^ ", " ^ (string_of_value v2) ^ ")"
-     | INL v -> "inl(" ^ (string_of_value v) ^ ")"
-     | INR  v -> "inr(" ^ (string_of_value v) ^ ")"
-     | FUN _ -> "FUNCTION( ... )"
+  | REF a -> "address(" ^ string_of_int a ^ ")"
+  | BOOL b -> string_of_bool b
+  | INT n -> string_of_int n
+  | UNIT -> "()"
+  | PAIR (v1, v2) -> "(" ^ string_of_value v1 ^ ", " ^ string_of_value v2 ^ ")"
+  | INL v -> "inl(" ^ string_of_value v ^ ")"
+  | INR v -> "inr(" ^ string_of_value v ^ ")"
+  | FUN _ -> "FUNCTION( ... )"
 
 (* update : (env * binding) -> env
    update : (store * (address * value)) -> store
 *)
-let update(env, (x, v)) = fun y -> if x = y then v else env y
+let update (env, (x, v)) =
+ fun y ->
+  if x = y then
+    v
+  else
+    env y
 
-let readint () = let _ = print_string "input> " in read_int()
+let readint () =
+  let _ = print_string "input> " in
+  read_int ()
 
 let do_unary = function
-  | (NOT,  BOOL m) -> BOOL (not m)
-  | (NEG,  INT m)  -> INT (-m)
-  | (READ, UNIT)   -> INT (readint())
-  | (op, _) -> complain ("malformed unary operator: " ^ (string_of_unary_oper op))
+  | NOT, BOOL m -> BOOL (not m)
+  | NEG, INT m -> INT (-m)
+  | READ, UNIT -> INT (readint ())
+  | op, _ -> complain ("malformed unary operator: " ^ string_of_unary_oper op)
 
 let do_oper = function
-  | (AND,  BOOL m,  BOOL n) -> BOOL (m && n)
-  | (OR,   BOOL m,  BOOL n) -> BOOL (m || n)
-  | (EQB,  BOOL m,  BOOL n) -> BOOL (m = n)
-  | (LT,   INT m,   INT n)  -> BOOL (m < n)
-  | (EQI,  INT m,   INT n)  -> BOOL (m = n)
-  | (ADD,  INT m,   INT n)  -> INT (m + n)
-  | (SUB,  INT m,   INT n)  -> INT (m - n)
-  | (MUL,  INT m,   INT n)  -> INT (m * n)
-  | (DIV,  INT m,   INT n)  -> INT (m / n)
-  | (op, _, _)  -> complain ("malformed binary operator: " ^ (string_of_oper op))
+  | AND, BOOL m, BOOL n -> BOOL (m && n)
+  | OR, BOOL m, BOOL n -> BOOL (m || n)
+  | EQB, BOOL m, BOOL n -> BOOL (m = n)
+  | LT, INT m, INT n -> BOOL (m < n)
+  | EQI, INT m, INT n -> BOOL (m = n)
+  | ADD, INT m, INT n -> INT (m + n)
+  | SUB, INT m, INT n -> INT (m - n)
+  | MUL, INT m, INT n -> INT (m * n)
+  | DIV, INT m, INT n -> INT (m / n)
+  | op, _, _ -> complain ("malformed binary operator: " ^ string_of_oper op)
 
 let do_deref = function
-  | (REF a, store) -> (store a, store)
-  | (_, _)  -> complain "deref expecting address"
+  | REF a, store -> (store a, store)
+  | _, _ -> complain "deref expecting address"
 
 let next_address = ref 0
 
-let new_address () = let a = !next_address in (next_address := a + 1; a)
+let new_address () =
+  let a = !next_address in
+  next_address := a + 1;
+  a
 
 let do_ref = function
-  | (v, store) -> let a = new_address () in (REF a, update(store, (a, v)))
+  | v, store ->
+      let a = new_address () in
+      (REF a, update (store, (a, v)))
 
-let do_assign a = function
-  | (v, store) -> (UNIT, update(store, (a, v)))
+let do_assign a = function v, store -> (UNIT, update (store, (a, v)))
 
 (*
     interpret : (expr * env * store) -> (value * store)
               : (expr * (var -> value) * address -> value) -> value
 *)
 let rec interpret (e, env, store) =
-    match e with
-    | Unit             -> (UNIT, store)
-    | Var x            -> (env x, store)
-    | Integer n        -> (INT n, store)
-    | Boolean b        -> (BOOL b, store)
-
-    | Seq []           -> (UNIT, store)  (* should not be seen ... *)
-    | Seq [e]          -> interpret (e, env, store)
-    | Seq(e :: rest)  -> let _, store1 = interpret(e, env, store)
-                          in interpret(Seq rest, env, store1)
-    | While(e1, e2)   -> let (v, store') = interpret(e1, env, store) in
-                          (match v with
-                          | BOOL true -> interpret(Seq [e2; e], env, store')
-                          | BOOL false -> (UNIT, store')
-                          | _ -> complain "runtime error.  Expecting a boolean!"
-                          )
-    | Ref e            -> do_ref(interpret(e, env, store))
-    | Deref e          -> do_deref(interpret(e, env, store))
-    | Assign(e1, e2)   -> (match interpret(e1, env, store) with
-                           | (REF a, store') -> do_assign a (interpret(e2, env, store'))
-                           | _ -> complain "runtime error : expecting an address on left side of assignment"
-                           )
-    | UnaryOp(op, e)   -> let (v, store') = interpret(e, env, store) in (do_unary(op, v), store')
-    | Op(e1, op, e2)   -> let (v1, store1) = interpret(e1, env, store) in
-                          let (v2, store2) = interpret(e2, env, store1) in (do_oper(op, v1, v2), store2)
-    | If(e1, e2, e3)   -> let (v, store') = interpret(e1, env, store) in
-                          (match v with
-                          | BOOL true -> interpret(e2, env, store')
-                          | BOOL false -> interpret(e3, env, store')
-                          | _ -> complain "runtime error.  Expecting a boolean!"
-                          )
-    | Pair(e1, e2)     -> let (v1, store1) = interpret(e1, env, store) in
-                          let (v2, store2) = interpret(e2, env, store1) in (PAIR(v1, v2), store2)
-    | Fst e            -> (match interpret(e, env, store) with
-                           | (PAIR (v1, _), store') -> (v1, store')
-                           |  _ -> complain "runtime error.  Expecting a pair!"
-                          )
-    | Snd e            -> (match interpret(e, env, store) with
-                           | (PAIR (_, v2), store') -> (v2, store')
-                           |  _ -> complain "runtime error.  Expecting a pair!"
-                          )
-    | Inl e            -> let (v, store') = interpret(e, env, store) in (INL v, store')
-    | Inr e            -> let (v, store') = interpret(e, env, store) in (INR v, store')
-    | Case(e, (x1, e1), (x2, e2)) ->
-      let (v, store') = interpret(e, env, store) in
-       (match v with
-       | INL v' -> interpret(e1, update(env, (x1, v')), store')
-       | INR v' -> interpret(e2, update(env, (x2, v')), store')
-       | _ -> complain "runtime error.  Expecting inl or inr!"
-       )
-    | Lambda(x, e)     -> (FUN (fun (v, s) -> interpret(e, update(env, (x, v)), s)), store)
-    | App(e1, e2)      -> let (v2, store1) = interpret(e2, env, store) in
-                          let (v1, store2) =  interpret(e1, env, store1) in
-                           (match v1 with
-                           | FUN f -> f (v2, store2)
-                           | _ -> complain "runtime error.  Expecting a function!"
-                          )
-    | LetFun(f, (x, body), e) ->
-       let new_env = update(env, (f, FUN (fun (v, s) -> interpret(body, update(env, (x, v)), s))))
-       in interpret(e, new_env, store)
-    | LetRecFun(f, (x, body), e) ->
-       let rec new_env g = (* a recursive environment! *)
-           if g = f then FUN (fun (v, s) -> interpret(body, update(new_env, (x, v)), s)) else env g
-       in interpret(e, new_env, store)
+  match e with
+  | Unit -> (UNIT, store)
+  | Var x -> (env x, store)
+  | Integer n -> (INT n, store)
+  | Boolean b -> (BOOL b, store)
+  | Seq [] -> (UNIT, store) (* should not be seen ... *)
+  | Seq [ e ] -> interpret (e, env, store)
+  | Seq (e :: rest) ->
+      let _, store1 = interpret (e, env, store) in
+      interpret (Seq rest, env, store1)
+  | While (e1, e2) -> (
+      let v, store' = interpret (e1, env, store) in
+      match v with
+      | BOOL true -> interpret (Seq [ e2; e ], env, store')
+      | BOOL false -> (UNIT, store')
+      | _ -> complain "runtime error.  Expecting a boolean!")
+  | Ref e -> do_ref (interpret (e, env, store))
+  | Deref e -> do_deref (interpret (e, env, store))
+  | Assign (e1, e2) -> (
+      match interpret (e1, env, store) with
+      | REF a, store' -> do_assign a (interpret (e2, env, store'))
+      | _ ->
+          complain
+            "runtime error : expecting an address on left side of assignment")
+  | UnaryOp (op, e) ->
+      let v, store' = interpret (e, env, store) in
+      (do_unary (op, v), store')
+  | Op (e1, op, e2) ->
+      let v1, store1 = interpret (e1, env, store) in
+      let v2, store2 = interpret (e2, env, store1) in
+      (do_oper (op, v1, v2), store2)
+  | If (e1, e2, e3) -> (
+      let v, store' = interpret (e1, env, store) in
+      match v with
+      | BOOL true -> interpret (e2, env, store')
+      | BOOL false -> interpret (e3, env, store')
+      | _ -> complain "runtime error.  Expecting a boolean!")
+  | Pair (e1, e2) ->
+      let v1, store1 = interpret (e1, env, store) in
+      let v2, store2 = interpret (e2, env, store1) in
+      (PAIR (v1, v2), store2)
+  | Fst e -> (
+      match interpret (e, env, store) with
+      | PAIR (v1, _), store' -> (v1, store')
+      | _ -> complain "runtime error.  Expecting a pair!")
+  | Snd e -> (
+      match interpret (e, env, store) with
+      | PAIR (_, v2), store' -> (v2, store')
+      | _ -> complain "runtime error.  Expecting a pair!")
+  | Inl e ->
+      let v, store' = interpret (e, env, store) in
+      (INL v, store')
+  | Inr e ->
+      let v, store' = interpret (e, env, store) in
+      (INR v, store')
+  | Case (e, (x1, e1), (x2, e2)) -> (
+      let v, store' = interpret (e, env, store) in
+      match v with
+      | INL v' -> interpret (e1, update (env, (x1, v')), store')
+      | INR v' -> interpret (e2, update (env, (x2, v')), store')
+      | _ -> complain "runtime error.  Expecting inl or inr!")
+  | Lambda (x, e) ->
+      (FUN (fun (v, s) -> interpret (e, update (env, (x, v)), s)), store)
+  | App (e1, e2) -> (
+      let v2, store1 = interpret (e2, env, store) in
+      let v1, store2 = interpret (e1, env, store1) in
+      match v1 with
+      | FUN f -> f (v2, store2)
+      | _ -> complain "runtime error.  Expecting a function!")
+  | LetFun (f, (x, body), e) ->
+      let new_env =
+        update
+          ( env,
+            (f, FUN (fun (v, s) -> interpret (body, update (env, (x, v)), s)))
+          )
+      in
+      interpret (e, new_env, store)
+  | LetRecFun (f, (x, body), e) ->
+      let rec new_env g =
+        (* a recursive environment! *)
+        if g = f then
+          FUN (fun (v, s) -> interpret (body, update (new_env, (x, v)), s))
+        else
+          env g
+      in
+      interpret (e, new_env, store)
 
 (* env_empty : env *)
 let empty_env = fun x -> complain (x ^ " is not defined!\n")
 
 (* store_empty : env *)
-let empty_store = fun x -> complain ((string_of_int x) ^ " is not allocated!\n")
+let empty_store = fun x -> complain (string_of_int x ^ " is not allocated!\n")
 
 (* interpret_top_level : expr -> value *)
-let interpret_top_level e = let (v, _) = interpret(e, empty_env, empty_store) in v
-
+let interpret_top_level e =
+  let v, _ = interpret (e, empty_env, empty_store) in
+  v

--- a/slang/interp_0.mli
+++ b/slang/interp_0.mli
@@ -1,23 +1,19 @@
-
 type address
-
 
 type store = address -> value
 
 and value =
-     | REF of address
-     | INT of int
-     | BOOL of bool
-     | UNIT
-     | PAIR of value * value
-     | INL of value
-     | INR of value
-     | FUN of ((value * store) -> (value * store))
+  | REF of address
+  | INT of int
+  | BOOL of bool
+  | UNIT
+  | PAIR of value * value
+  | INL of value
+  | INR of value
+  | FUN of (value * store -> value * store)
 
 type env = Ast.var -> value
 
 val string_of_value : value -> string
-
-val interpret :  Ast.expr * env * store -> (value * store)
-
+val interpret : Ast.expr * env * store -> value * store
 val interpret_top_level : Ast.expr -> value

--- a/slang/interp_1.ml
+++ b/slang/interp_1.ml
@@ -12,7 +12,6 @@ Timothy G. Griffin (tgg22@cam.ac.uk)
 
 *)
 
-
 open Ast
 
 type expr_i1 = Ast.expr
@@ -22,15 +21,15 @@ let complain = Errors.complain
 type address = int
 
 type value =
-     | REF of address
-     | INT of int
-     | BOOL of bool
-     | UNIT
-     | PAIR of value * value
-     | INL of value
-     | INR of value
-     | REC_CLOSURE of closure
-     | CLOSURE of closure
+  | REF of address
+  | INT of int
+  | BOOL of bool
+  | UNIT
+  | PAIR of value * value
+  | INL of value
+  | INR of value
+  | REC_CLOSURE of closure
+  | CLOSURE of closure
 
 and closure = var * expr_i1 * env
 
@@ -55,43 +54,41 @@ and continuation_action =
   | APPLY of value
   | ARG of expr_i1 * env
 
-and continuation = continuation_action  list
-
+and continuation = continuation_action list
 and binding = var * value
-
 and env = binding list
 
 type state =
-   | INSPECT of expr_i1 * env * continuation
-   | COMPUTE of continuation * value
-
-
+  | INSPECT of expr_i1 * env * continuation
+  | COMPUTE of continuation * value
 
 (* update : (env * binding) -> env *)
-let update(env, (x, v)) = (x, v) :: env
+let update (env, (x, v)) = (x, v) :: env
 
 (* When making a closure, only include bindings that
    are needed.
 *)
 
-let rec inlist x = function
-  | [] -> false
-  | y :: rest -> (x = y) || (inlist x rest)
+let rec inlist x = function [] -> false | y :: rest -> x = y || inlist x rest
 
 let rec filter_env fvars = function
   | [] -> []
-  | (x, v) :: rest -> if inlist x fvars then (x, v) :: (filter_env fvars rest) else (filter_env fvars rest)
+  | (x, v) :: rest ->
+      if inlist x fvars then
+        (x, v) :: filter_env fvars rest
+      else
+        filter_env fvars rest
 
-let mk_fun(x, body, env) =
-    let fvars = Free_vars.free_vars ([x], body) in
-    let smaller_env = filter_env fvars env in
-      CLOSURE(x, body, smaller_env)
+let mk_fun (x, body, env) =
+  let fvars = Free_vars.free_vars ([ x ], body) in
+  let smaller_env = filter_env fvars env in
+  CLOSURE (x, body, smaller_env)
 
-let mk_rec_fun(f, x, body, env) =
-    let fvars = Free_vars.free_vars ([f; x], body) in
-    let smaller_env = filter_env fvars env in
-    let f_binding = (f, REC_CLOSURE(x, body, [])) in
-       CLOSURE(x, body, f_binding :: smaller_env)
+let mk_rec_fun (f, x, body, env) =
+  let fvars = Free_vars.free_vars ([ f; x ], body) in
+  let smaller_env = filter_env fvars env in
+  let f_binding = (f, REC_CLOSURE (x, body, [])) in
+  CLOSURE (x, body, f_binding :: smaller_env)
 
 (*
       for a recursive function f we want
@@ -99,183 +96,207 @@ let mk_rec_fun(f, x, body, env) =
       lookup (env, f) = FUN(true, (x, body, env))
 *)
 let lookup (env, x) =
-    let rec aux = function
-      | [] -> complain (x ^ " is not defined!\n")
-      | (y, v) :: rest ->
-          if x = y
-          then match v with
-             | REC_CLOSURE(z, body, _) ->
-                 CLOSURE(z, body, (y, REC_CLOSURE(z, body, [])) :: rest)
-             | _ -> v
-          else aux rest
-      in aux env
+  let rec aux = function
+    | [] -> complain (x ^ " is not defined!\n")
+    | (y, v) :: rest ->
+        if x = y then
+          match
+            v
+          with
+          | REC_CLOSURE (z, body, _) ->
+              CLOSURE (z, body, (y, REC_CLOSURE (z, body, [])) :: rest)
+          | _ -> v
+        else
+          aux rest
+  in
+  aux env
 
-
-let readint () = let _ = print_string "input> " in read_int()
+let readint () =
+  let _ = print_string "input> " in
+  read_int ()
 
 let do_unary = function
-  | (NOT,  BOOL m) -> BOOL (not m)
-  | (NEG,  INT m)  -> INT (-m)
-  | (READ, UNIT)   -> INT (readint())
-  | (op, _) -> complain ("malformed unary operator: " ^ (string_of_unary_oper op))
+  | NOT, BOOL m -> BOOL (not m)
+  | NEG, INT m -> INT (-m)
+  | READ, UNIT -> INT (readint ())
+  | op, _ -> complain ("malformed unary operator: " ^ string_of_unary_oper op)
 
 let do_oper = function
-  | (AND,  BOOL m,  BOOL n) -> BOOL (m && n)
-  | (OR,   BOOL m,  BOOL n) -> BOOL (m || n)
-  | (EQB,  BOOL m,  BOOL n) -> BOOL (m = n)
-  | (LT,   INT m,   INT n)  -> BOOL (m < n)
-  | (EQI,  INT m,   INT n)  -> BOOL (m = n)
-  | (ADD,  INT m,   INT n)  -> INT (m + n)
-  | (SUB,  INT m,   INT n)  -> INT (m - n)
-  | (MUL,  INT m,   INT n)  -> INT (m * n)
-  | (DIV,  INT m,   INT n)  -> INT (m / n)
-  | (op, _, _)  -> complain ("malformed binary operator: " ^ (string_of_oper op))
-
+  | AND, BOOL m, BOOL n -> BOOL (m && n)
+  | OR, BOOL m, BOOL n -> BOOL (m || n)
+  | EQB, BOOL m, BOOL n -> BOOL (m = n)
+  | LT, INT m, INT n -> BOOL (m < n)
+  | EQI, INT m, INT n -> BOOL (m = n)
+  | ADD, INT m, INT n -> INT (m + n)
+  | SUB, INT m, INT n -> INT (m - n)
+  | MUL, INT m, INT n -> INT (m * n)
+  | DIV, INT m, INT n -> INT (m / n)
+  | op, _, _ -> complain ("malformed binary operator: " ^ string_of_oper op)
 
 let string_of_list sep f l =
-   let rec aux f = function
-     | [] -> ""
-     | [t] -> (f t)
-     | t :: rest -> (f t) ^  sep  ^ (aux f rest)
-   in "[" ^ (aux f l) ^ "]"
-
+  let rec aux f = function
+    | [] -> ""
+    | [ t ] -> f t
+    | t :: rest -> f t ^ sep ^ aux f rest
+  in
+  "[" ^ aux f l ^ "]"
 
 let rec string_of_value = function
-     | REF a          -> "REF(" ^ (string_of_int a) ^ ")"
-     | BOOL b         -> string_of_bool b
-     | INT n          -> string_of_int n
-     | UNIT           -> "UNIT"
-     | PAIR(v1, v2)   -> "PAIR(" ^ (string_of_value v1) ^ ", " ^ (string_of_value v2) ^ ")"
-     | INL v          -> "INL(" ^ (string_of_value v) ^ ")"
-     | INR v          -> "INR(" ^ (string_of_value v) ^ ")"
-     | CLOSURE cl     -> "CLOSURE(" ^ (string_of_closure cl) ^ ")"
-     | REC_CLOSURE cl -> "REC_CLOSURE(" ^ string_of_closure cl ^ ")"
+  | REF a -> "REF(" ^ string_of_int a ^ ")"
+  | BOOL b -> string_of_bool b
+  | INT n -> string_of_int n
+  | UNIT -> "UNIT"
+  | PAIR (v1, v2) ->
+      "PAIR(" ^ string_of_value v1 ^ ", " ^ string_of_value v2 ^ ")"
+  | INL v -> "INL(" ^ string_of_value v ^ ")"
+  | INR v -> "INR(" ^ string_of_value v ^ ")"
+  | CLOSURE cl -> "CLOSURE(" ^ string_of_closure cl ^ ")"
+  | REC_CLOSURE cl -> "REC_CLOSURE(" ^ string_of_closure cl ^ ")"
 
-and string_of_closure (x, e, env) = x ^ ", " ^ (Ast.string_of_expr e) ^  ", " ^ (string_of_env env)
+and string_of_closure (x, e, env) =
+  x ^ ", " ^ Ast.string_of_expr e ^ ", " ^ string_of_env env
 
 and string_of_env env = string_of_list ",\n " string_of_binding env
-
-and string_of_binding (x, v) =    "(" ^ x ^ ", " ^ (string_of_value v) ^ ")"
+and string_of_binding (x, v) = "(" ^ x ^ ", " ^ string_of_value v ^ ")"
 
 let string_of_expr_list = string_of_list "; " Ast.string_of_expr
 
 let string_of_continuation_action = function
-  | UNARY op     -> "UNARY " ^ (string_of_unary_oper op)
-  | MKPAIR v     -> "MKPAIR " ^ (string_of_value v)
-  | FST          -> "FST"
-  | SND          -> "SND"
-  | MKINL        -> "MKINL"
-  | MKINR        -> "MKINR"
-  | APPLY v     -> "APPLY " ^ (string_of_value v)
-  | ARG (e, env) -> "ARG("  ^ (Ast.string_of_expr e)   ^ ", " ^ (string_of_env env) ^ ")"
-  | OPER (op, v) -> "OPER(" ^ (string_of_oper op) ^ ", " ^ (string_of_value v) ^ ")"
-  | CASE(x1, e1, x2, e2, env) ->
-      "CASE(" ^ x1 ^ ", "
-                ^ (Ast.string_of_expr e1) ^ ", "
-                ^ x2 ^ ", "
-                ^ (Ast.string_of_expr e2) ^ ", "
-                ^ (string_of_env env) ^ ")"
-  | PAIR_FST (e, env)    ->
-      "PAIR_FST(" ^ (Ast.string_of_expr e) ^ ", " ^ (string_of_env env) ^ ")"
-  | OPER_FST(e, env, op) ->
-      "OPER_FST(" ^ (Ast.string_of_expr e) ^ ", " ^ (string_of_env env) ^ ", " ^ (string_of_oper op) ^ ")"
+  | UNARY op -> "UNARY " ^ string_of_unary_oper op
+  | MKPAIR v -> "MKPAIR " ^ string_of_value v
+  | FST -> "FST"
+  | SND -> "SND"
+  | MKINL -> "MKINL"
+  | MKINR -> "MKINR"
+  | APPLY v -> "APPLY " ^ string_of_value v
+  | ARG (e, env) ->
+      "ARG(" ^ Ast.string_of_expr e ^ ", " ^ string_of_env env ^ ")"
+  | OPER (op, v) -> "OPER(" ^ string_of_oper op ^ ", " ^ string_of_value v ^ ")"
+  | CASE (x1, e1, x2, e2, env) ->
+      "CASE(" ^ x1 ^ ", " ^ Ast.string_of_expr e1 ^ ", " ^ x2 ^ ", "
+      ^ Ast.string_of_expr e2 ^ ", " ^ string_of_env env ^ ")"
+  | PAIR_FST (e, env) ->
+      "PAIR_FST(" ^ Ast.string_of_expr e ^ ", " ^ string_of_env env ^ ")"
+  | OPER_FST (e, env, op) ->
+      "OPER_FST(" ^ Ast.string_of_expr e ^ ", " ^ string_of_env env ^ ", "
+      ^ string_of_oper op ^ ")"
   | IF (e1, e2, env) ->
-      "IF(" ^ (Ast.string_of_expr e1) ^ ", " ^ (Ast.string_of_expr e2) ^ ", " ^ (string_of_env env) ^ ")"
-  | ASSIGN v -> "MKPAIR " ^ (string_of_value v)
+      "IF(" ^ Ast.string_of_expr e1 ^ ", " ^ Ast.string_of_expr e2 ^ ", "
+      ^ string_of_env env ^ ")"
+  | ASSIGN v -> "MKPAIR " ^ string_of_value v
   | ASSIGN_FST (e, env) ->
-     "ASSIGN_FST(" ^ (Ast.string_of_expr e) ^ ", " ^ (string_of_env env) ^ ")"
-  | TAIL (el , env) -> "TAIL("  ^ (string_of_expr_list el)   ^ ", " ^ (string_of_env env) ^ ")"
+      "ASSIGN_FST(" ^ Ast.string_of_expr e ^ ", " ^ string_of_env env ^ ")"
+  | TAIL (el, env) ->
+      "TAIL(" ^ string_of_expr_list el ^ ", " ^ string_of_env env ^ ")"
   | WHILE (e1, e2, env) ->
-      "WHILE(" ^ (Ast.string_of_expr e1) ^ ", " ^ (Ast.string_of_expr e2) ^ ", " ^ (string_of_env env) ^ ")"
+      "WHILE(" ^ Ast.string_of_expr e1 ^ ", " ^ Ast.string_of_expr e2 ^ ", "
+      ^ string_of_env env ^ ")"
   | MKREF -> "MKREF"
   | DEREF -> "DEREF"
 
 let string_of_continuation = string_of_list ";\n " string_of_continuation_action
 
 let string_of_state = function
-   | INSPECT(e, env, cnt) ->
-      "INSPECT(" ^ (Ast.string_of_expr e) ^ ", "
-              ^ (string_of_env env) ^ ", "
-              ^ (string_of_continuation cnt) ^ ")"
-   | COMPUTE(cnt, v)     ->
-      "COMPUTE(" ^ (string_of_continuation cnt) ^ ", "
-               ^ (string_of_value v) ^ ")"
+  | INSPECT (e, env, cnt) ->
+      "INSPECT(" ^ Ast.string_of_expr e ^ ", " ^ string_of_env env ^ ", "
+      ^ string_of_continuation cnt ^ ")"
+  | COMPUTE (cnt, v) ->
+      "COMPUTE(" ^ string_of_continuation cnt ^ ", " ^ string_of_value v ^ ")"
 
-
-let heap  = Array.make Option.heap_max (INT 0)
-
+let heap = Array.make Option.heap_max (INT 0)
 let next_address = ref 0
 
-let new_address () = let a = !next_address in (next_address := a + 1; a)
+let new_address () =
+  let a = !next_address in
+  next_address := a + 1;
+  a
 
-let mk_ref v = let a = new_address () in let _ = heap.(a) <- v in REF a
+let mk_ref v =
+  let a = new_address () in
+  let _ = heap.(a) <- v in
+  REF a
 
-let do_assign a v = (heap.(a) <- v)
-
+let do_assign a v = heap.(a) <- v
 
 let step = function
- (* INSPECT --> INSPECT *)
- | INSPECT(UnaryOp (op, e),              env, k) -> INSPECT(e,  env, (UNARY op) :: k)
- | INSPECT (Op (e1, op, e2),              env, k) -> INSPECT (e1, env, OPER_FST (e2, env, op) :: k)
- | INSPECT (If (e1, e2, e3),              env, k) -> INSPECT (e1, env, IF (e2, e3, env) :: k)
- | INSPECT (Pair (e1, e2),                env, k) -> INSPECT (e1, env, PAIR_FST (e2, env) :: k)
- | INSPECT (Fst (e),                       env, k) -> INSPECT (e,  env, FST :: k)
- | INSPECT (Snd (e),                       env, k) -> INSPECT (e,  env, SND :: k)
- | INSPECT (Inl (e),                       env, k) -> INSPECT (e,  env, MKINL :: k)
- | INSPECT (Inr (e),                       env, k) -> INSPECT (e,  env, MKINR :: k)
- | INSPECT (Case (e, (x1, e1), (x2, e2)), env, k) -> INSPECT (e,  env, CASE (x1, e1, x2, e2, env) :: k)
- | INSPECT (App (e1, e2),                 env, k) -> INSPECT (e2, env, ARG (e1, env) :: k)
- | INSPECT (LetFun (f, (x, body), e),     env, k) -> INSPECT (e, update (env, (f, mk_fun (x, body, env))) , k)
- | INSPECT (LetRecFun (f, (x, body), e),  env, k) -> INSPECT (e, update (env, (f, mk_rec_fun (f, x, body, env))) , k)
- | INSPECT (Ref (e),                       env, k) -> INSPECT (e,  env, MKREF :: k)
- | INSPECT (Deref (e),                     env, k) -> INSPECT (e,  env, DEREF :: k)
- | INSPECT (Assign (e1, e2),              env, k) -> INSPECT (e1, env, ASSIGN_FST (e2, env) :: k)
- | INSPECT (Seq ([e]),                     env, k) -> INSPECT (e, env, k)
- | INSPECT (Seq ((e :: rest)),             env, k) -> INSPECT (e, env, TAIL (rest, env) :: k)
- | INSPECT (While (e1, e2),               env, k) -> INSPECT (e1, env, WHILE (e1, e2, env) :: k)
- (* INSPECT --> COMPUTE *)
- | INSPECT (Unit,              _, k) -> COMPUTE (k, UNIT)
- | INSPECT (Var x,           env, k) -> COMPUTE (k, lookup (env, x))
- | INSPECT (Integer (n),         _, k) -> COMPUTE (k, INT n)
- | INSPECT (Boolean (b),         _, k) -> COMPUTE (k, BOOL b)
- | INSPECT (Lambda (x, body), env, k) -> COMPUTE (k, mk_fun (x, body, env))
- (* COMPUTE --> COMPUTE *)
- | COMPUTE ((UNARY op) :: k,    v) -> COMPUTE (k ,(do_unary (op, v)))
- | COMPUTE (OPER (op, v1) :: k, v2) -> COMPUTE (k, do_oper (op, v1, v2))
- | COMPUTE ((MKPAIR v1) :: k,  v2) -> COMPUTE (k, PAIR (v1, v2))
- | COMPUTE (FST :: k,  PAIR (v, _)) -> COMPUTE (k, v)
- | COMPUTE (SND :: k,  PAIR (_, v)) -> COMPUTE (k, v)
- | COMPUTE (MKINL :: k,         v) -> COMPUTE (k, INL v)
- | COMPUTE (MKINR :: k,         v) -> COMPUTE (k, INR v)
- | COMPUTE (MKREF :: k,         v) -> COMPUTE (k , mk_ref v)
- | COMPUTE (DEREF :: k,     REF a) -> COMPUTE (k , heap.(a))
- | COMPUTE (ASSIGN (REF a) :: k, v) -> let _ = do_assign a v in COMPUTE (k , UNIT)
- | COMPUTE (WHILE (_, _, _) :: k,         BOOL false) -> COMPUTE (k, UNIT)
- (* COMPUTE --> INSPECT *)
- | COMPUTE (OPER_FST (e2, env, op) :: k,         v1)  -> INSPECT (e2, env, OPER (op, v1) :: k)
- | COMPUTE ((APPLY v2) :: k, CLOSURE (x, body, env))  -> INSPECT (body, update (env, (x, v2)), k)
- | COMPUTE ((APPLY v2) :: k, REC_CLOSURE (x, body, env)) -> INSPECT (body, update (env, (x, v2)), k)
- | COMPUTE (ARG (e2, env) :: k,                   v)  -> INSPECT (e2, env, (APPLY v) :: k)
- | COMPUTE (PAIR_FST (e2, env) :: k,             v1)  -> INSPECT (e2, env, (MKPAIR v1) :: k)
- | COMPUTE (CASE (x1, e1, _, _, env) :: k,  INL v)  -> INSPECT (e1, update (env, (x1, v)), k)
- | COMPUTE (CASE (_, _, x2, e2, env) :: k,  INR v)  -> INSPECT (e2, update (env, (x2, v)), k)
- | COMPUTE (IF (e2, _, env) :: k,        BOOL true)  -> INSPECT (e2, env, k)
- | COMPUTE (IF (_, e3, env) :: k,       BOOL false)  -> INSPECT (e3, env, k)
-
- | COMPUTE (ASSIGN_FST (e2, env) :: k,            v)  -> INSPECT (e2, env, ASSIGN v :: k)
- | COMPUTE (WHILE (e1, e2, env) :: k,     BOOL true)  -> INSPECT (Seq [e2; e1], env, WHILE (e1, e2, env)::k)
- | COMPUTE (TAIL (el, env) :: k,     _)  ->  INSPECT (Seq el, env, k)
- | state -> complain ("step : malformed state = " ^ string_of_state state ^ "\n")
+  (* INSPECT --> INSPECT *)
+  | INSPECT (UnaryOp (op, e), env, k) -> INSPECT (e, env, UNARY op :: k)
+  | INSPECT (Op (e1, op, e2), env, k) ->
+      INSPECT (e1, env, OPER_FST (e2, env, op) :: k)
+  | INSPECT (If (e1, e2, e3), env, k) -> INSPECT (e1, env, IF (e2, e3, env) :: k)
+  | INSPECT (Pair (e1, e2), env, k) -> INSPECT (e1, env, PAIR_FST (e2, env) :: k)
+  | INSPECT (Fst e, env, k) -> INSPECT (e, env, FST :: k)
+  | INSPECT (Snd e, env, k) -> INSPECT (e, env, SND :: k)
+  | INSPECT (Inl e, env, k) -> INSPECT (e, env, MKINL :: k)
+  | INSPECT (Inr e, env, k) -> INSPECT (e, env, MKINR :: k)
+  | INSPECT (Case (e, (x1, e1), (x2, e2)), env, k) ->
+      INSPECT (e, env, CASE (x1, e1, x2, e2, env) :: k)
+  | INSPECT (App (e1, e2), env, k) -> INSPECT (e2, env, ARG (e1, env) :: k)
+  | INSPECT (LetFun (f, (x, body), e), env, k) ->
+      INSPECT (e, update (env, (f, mk_fun (x, body, env))), k)
+  | INSPECT (LetRecFun (f, (x, body), e), env, k) ->
+      INSPECT (e, update (env, (f, mk_rec_fun (f, x, body, env))), k)
+  | INSPECT (Ref e, env, k) -> INSPECT (e, env, MKREF :: k)
+  | INSPECT (Deref e, env, k) -> INSPECT (e, env, DEREF :: k)
+  | INSPECT (Assign (e1, e2), env, k) ->
+      INSPECT (e1, env, ASSIGN_FST (e2, env) :: k)
+  | INSPECT (Seq [ e ], env, k) -> INSPECT (e, env, k)
+  | INSPECT (Seq (e :: rest), env, k) -> INSPECT (e, env, TAIL (rest, env) :: k)
+  | INSPECT (While (e1, e2), env, k) ->
+      INSPECT (e1, env, WHILE (e1, e2, env) :: k)
+  (* INSPECT --> COMPUTE *)
+  | INSPECT (Unit, _, k) -> COMPUTE (k, UNIT)
+  | INSPECT (Var x, env, k) -> COMPUTE (k, lookup (env, x))
+  | INSPECT (Integer n, _, k) -> COMPUTE (k, INT n)
+  | INSPECT (Boolean b, _, k) -> COMPUTE (k, BOOL b)
+  | INSPECT (Lambda (x, body), env, k) -> COMPUTE (k, mk_fun (x, body, env))
+  (* COMPUTE --> COMPUTE *)
+  | COMPUTE (UNARY op :: k, v) -> COMPUTE (k, do_unary (op, v))
+  | COMPUTE (OPER (op, v1) :: k, v2) -> COMPUTE (k, do_oper (op, v1, v2))
+  | COMPUTE (MKPAIR v1 :: k, v2) -> COMPUTE (k, PAIR (v1, v2))
+  | COMPUTE (FST :: k, PAIR (v, _)) -> COMPUTE (k, v)
+  | COMPUTE (SND :: k, PAIR (_, v)) -> COMPUTE (k, v)
+  | COMPUTE (MKINL :: k, v) -> COMPUTE (k, INL v)
+  | COMPUTE (MKINR :: k, v) -> COMPUTE (k, INR v)
+  | COMPUTE (MKREF :: k, v) -> COMPUTE (k, mk_ref v)
+  | COMPUTE (DEREF :: k, REF a) -> COMPUTE (k, heap.(a))
+  | COMPUTE (ASSIGN (REF a) :: k, v) ->
+      let _ = do_assign a v in
+      COMPUTE (k, UNIT)
+  | COMPUTE (WHILE (_, _, _) :: k, BOOL false) -> COMPUTE (k, UNIT)
+  (* COMPUTE --> INSPECT *)
+  | COMPUTE (OPER_FST (e2, env, op) :: k, v1) ->
+      INSPECT (e2, env, OPER (op, v1) :: k)
+  | COMPUTE (APPLY v2 :: k, CLOSURE (x, body, env)) ->
+      INSPECT (body, update (env, (x, v2)), k)
+  | COMPUTE (APPLY v2 :: k, REC_CLOSURE (x, body, env)) ->
+      INSPECT (body, update (env, (x, v2)), k)
+  | COMPUTE (ARG (e2, env) :: k, v) -> INSPECT (e2, env, APPLY v :: k)
+  | COMPUTE (PAIR_FST (e2, env) :: k, v1) -> INSPECT (e2, env, MKPAIR v1 :: k)
+  | COMPUTE (CASE (x1, e1, _, _, env) :: k, INL v) ->
+      INSPECT (e1, update (env, (x1, v)), k)
+  | COMPUTE (CASE (_, _, x2, e2, env) :: k, INR v) ->
+      INSPECT (e2, update (env, (x2, v)), k)
+  | COMPUTE (IF (e2, _, env) :: k, BOOL true) -> INSPECT (e2, env, k)
+  | COMPUTE (IF (_, e3, env) :: k, BOOL false) -> INSPECT (e3, env, k)
+  | COMPUTE (ASSIGN_FST (e2, env) :: k, v) -> INSPECT (e2, env, ASSIGN v :: k)
+  | COMPUTE (WHILE (e1, e2, env) :: k, BOOL true) ->
+      INSPECT (Seq [ e2; e1 ], env, WHILE (e1, e2, env) :: k)
+  | COMPUTE (TAIL (el, env) :: k, _) -> INSPECT (Seq el, env, k)
+  | state ->
+      complain ("step : malformed state = " ^ string_of_state state ^ "\n")
 
 let rec driver n state =
-  let _ = if Option.verbose
-          then print_string ("\nstate " ^ string_of_int n ^ " = \n" ^ string_of_state state ^ "\n")
-          else ()
-  in match state with
-     | COMPUTE([], v) -> v
-     | _              -> driver (n + 1) (step state)
+  let _ =
+    if Option.verbose then
+      print_string
+        ("\nstate " ^ string_of_int n ^ " = \n" ^ string_of_state state ^ "\n")
+    else
+      ()
+  in
+  match state with COMPUTE ([], v) -> v | _ -> driver (n + 1) (step state)
 
-let eval(e, env) = driver 1 (INSPECT (e, env, []))
+let eval (e, env) = driver 1 (INSPECT (e, env, []))
 
 (* env_empty : env *)
 let env_empty = []

--- a/slang/interp_1.mli
+++ b/slang/interp_1.mli
@@ -1,18 +1,16 @@
-
 type expr_i1 = Ast.expr
-
 type address = int
 
 type value =
-     | REF of address
-     | INT of int
-     | BOOL of bool
-     | UNIT
-     | PAIR of value * value
-     | INL of value
-     | INR of value
-     | REC_CLOSURE of closure
-     | CLOSURE of closure
+  | REF of address
+  | INT of int
+  | BOOL of bool
+  | UNIT
+  | PAIR of value * value
+  | INL of value
+  | INR of value
+  | REC_CLOSURE of closure
+  | CLOSURE of closure
 
 and closure = Ast.var * expr_i1 * env
 
@@ -37,22 +35,16 @@ and continuation_action =
   | APPLY of value
   | ARG of expr_i1 * env
 
-and continuation = continuation_action  list
-
+and continuation = continuation_action list
 and binding = Ast.var * value
-
 and env = binding list
 
 type state =
-   | INSPECT of expr_i1 * env * continuation
-   | COMPUTE of continuation * value
+  | INSPECT of expr_i1 * env * continuation
+  | COMPUTE of continuation * value
 
 val step : state -> state
-
 val driver : int -> state -> value
-
 val eval : expr_i1 * env -> value
-
 val interpret : Ast.expr -> value
-
 val string_of_value : value -> string

--- a/slang/interp_2.ml
+++ b/slang/interp_2.ml
@@ -15,14 +15,16 @@ What do I mean by "high-level"?
 ---Program variables contained in code.
 *)
 
-
 open Ast
 open Errors
 
-module IntMap = Map.Make(struct type t = int let compare = compare end)
+module IntMap = Map.Make (struct
+  type t = int
+
+  let compare = compare
+end)
 
 type address = int
-
 type var = string
 
 type value =
@@ -62,19 +64,15 @@ and instruction =
   | WHILE of code * code
 
 and code = instruction list
-
 and binding = Ast.var * value
-
 and env = binding list
 
 type env_or_value = EV of env | V of value
-
 type env_value_stack = env_or_value list
 
 (* This is the the slang program state --- that is, values for references *)
 (* It is an array of referenced values together with next unallocated address *)
-type state = (value IntMap.t) * int
-
+type state = value IntMap.t * int
 type interp_state = code * env_value_stack * state
 
 (* Printing *)
@@ -82,71 +80,70 @@ type interp_state = code * env_value_stack * state
 let pr = Format.fprintf
 
 let pp_list fmt sep f l =
-   let rec aux f fmt = function
-     | [] -> ()
-     | [t] -> f fmt t
-     | t :: rest -> pr fmt "%a%(%)%a" f t sep (aux f) rest
-   in pr fmt "@[[%a]@]" (aux f) l
+  let rec aux f fmt = function
+    | [] -> ()
+    | [ t ] -> f fmt t
+    | t :: rest -> pr fmt "%a%(%)%a" f t sep (aux f) rest
+  in
+  pr fmt "@[[%a]@]" (aux f) l
 
 let rec pp_value fmt = function
-  | REF a          -> pr fmt "REF(%d)" a
-  | BOOL b         -> pr fmt "%b" b
-  | INT n          -> pr fmt "%d" n
-  | UNIT           -> pr fmt "UNIT"
-  | PAIR(v1, v2)   -> pr fmt "(%a, %a)" pp_value v1 pp_value v2
-  | INL v          -> pr fmt "inl(%a)" pp_value v
-  | INR  v         -> pr fmt "inr(%a)" pp_value v
-  | CLOSURE(cl)    -> pr fmt "CLOSURE(%a)" pp_closure cl
-  | REC_CLOSURE(c) -> pr fmt "REC_CLOSURE(%a)" pp_code c
+  | REF a -> pr fmt "REF(%d)" a
+  | BOOL b -> pr fmt "%b" b
+  | INT n -> pr fmt "%d" n
+  | UNIT -> pr fmt "UNIT"
+  | PAIR (v1, v2) -> pr fmt "(%a, %a)" pp_value v1 pp_value v2
+  | INL v -> pr fmt "inl(%a)" pp_value v
+  | INR v -> pr fmt "inr(%a)" pp_value v
+  | CLOSURE cl -> pr fmt "CLOSURE(%a)" pp_closure cl
+  | REC_CLOSURE c -> pr fmt "REC_CLOSURE(%a)" pp_code c
 
-and pp_closure fmt (c, env) =
-  pr fmt "(%a, %a)" pp_code c pp_env env
-
+and pp_closure fmt (c, env) = pr fmt "(%a, %a)" pp_code c pp_env env
 and pp_env fmt env = pp_list fmt ",@\n " pp_binding env
-
 and pp_binding fmt (x, v) = pr fmt "(%s, %a)" x pp_value v
 
 and pp_instruction fmt = function
- | UNARY op       -> pr fmt "@[UNARY %s@]" (string_of_uop op)
- | OPER op        -> pr fmt "@[OPER %s@]" (string_of_bop op)
- | MK_PAIR        -> pr fmt "MK_PAIR"
- | FST            -> pr fmt "FST"
- | SND            -> pr fmt "SND"
- | MK_INL         -> pr fmt "MK_INL"
- | MK_INR         -> pr fmt "MK_INR"
- | MK_REF         -> pr fmt "MK_REF"
- | PUSH v         -> pr fmt "PUSH %a" pp_value v
- | LOOKUP x       -> pr fmt "LOOKUP %s" x
- | TEST (c1, c2)  -> pr fmt "TEST(@[%a,@ %a)@]" pp_code c1 pp_code c2
- | CASE (c1, c2)  -> pr fmt "CASE(@[%a,@ %a)@]" pp_code c1 pp_code c2
- | WHILE (c1, c2) -> pr fmt "WHILE(@[%a,@ %a)@]" pp_code c1 pp_code c2
- | APPLY          -> pr fmt "APPLY"
- | BIND x         -> pr fmt "BIND %s" x
- | SWAP           -> pr fmt "SWAP"
- | POP            -> pr fmt "POP"
- | DEREF          -> pr fmt "DEREF"
- | ASSIGN         -> pr fmt "ASSIGN"
- | MK_CLOSURE c   -> pr fmt "MK_CLOSURE(%a)" pp_code c
- | MK_REC (f, c)  -> pr fmt "MK_REC(@[%s, %a)@]" f pp_code c
+  | UNARY op -> pr fmt "@[UNARY %s@]" (string_of_uop op)
+  | OPER op -> pr fmt "@[OPER %s@]" (string_of_bop op)
+  | MK_PAIR -> pr fmt "MK_PAIR"
+  | FST -> pr fmt "FST"
+  | SND -> pr fmt "SND"
+  | MK_INL -> pr fmt "MK_INL"
+  | MK_INR -> pr fmt "MK_INR"
+  | MK_REF -> pr fmt "MK_REF"
+  | PUSH v -> pr fmt "PUSH %a" pp_value v
+  | LOOKUP x -> pr fmt "LOOKUP %s" x
+  | TEST (c1, c2) -> pr fmt "TEST(@[%a,@ %a)@]" pp_code c1 pp_code c2
+  | CASE (c1, c2) -> pr fmt "CASE(@[%a,@ %a)@]" pp_code c1 pp_code c2
+  | WHILE (c1, c2) -> pr fmt "WHILE(@[%a,@ %a)@]" pp_code c1 pp_code c2
+  | APPLY -> pr fmt "APPLY"
+  | BIND x -> pr fmt "BIND %s" x
+  | SWAP -> pr fmt "SWAP"
+  | POP -> pr fmt "POP"
+  | DEREF -> pr fmt "DEREF"
+  | ASSIGN -> pr fmt "ASSIGN"
+  | MK_CLOSURE c -> pr fmt "MK_CLOSURE(%a)" pp_code c
+  | MK_REC (f, c) -> pr fmt "MK_REC(@[%s, %a)@]" f pp_code c
 
 and pp_code fmt c = pp_list fmt ";@\n " pp_instruction c
 
 let pp_env_or_value fmt = function
   | EV env -> pr fmt "EV %a" pp_env env
-  | V v    -> pr fmt "V %a" pp_value v
+  | V v -> pr fmt "V %a" pp_value v
 
 let pp_env_value_stack fmt n = pp_list fmt ";@\n " pp_env_or_value n
 
-let pp_state fmt (heap, i)  =
+let pp_state fmt (heap, i) =
   let rec aux fmt k =
-    if i > k
-    then pr fmt "%d -> %a@\n%a" k pp_value (IntMap.find k heap) aux (k+1)
-  in if i <> 0
-     then pr fmt "@\nHeap = @\n%a" aux 0
+    if i > k then
+      pr fmt "%d -> %a@\n%a" k pp_value (IntMap.find k heap) aux (k + 1)
+  in
+  if i <> 0 then
+    pr fmt "@\nHeap = @\n%a" aux 0
 
 let pp_interp_state fmt (c, evs, s) =
-  pr fmt "@\nCode Stack = @\n%a@\nEnv/Value Stack = @\n%a%a"
-    pp_code c pp_env_value_stack evs pp_state s
+  pr fmt "@\nCode Stack = @\n%a@\nEnv/Value Stack = @\n%a%a" pp_code c
+    pp_env_value_stack evs pp_state s
 
 let string_of_instruction = Format.asprintf "%a" pp_instruction
 let string_of_value = Format.asprintf "%a" pp_value
@@ -159,23 +156,23 @@ let string_of_code = Format.asprintf "%a" pp_code
    and give it value v
 *)
 let allocate (heap, i) v =
-    if i < Option.heap_max
-    then let heap = IntMap.add i v heap
-         in (i, (heap, i+1))
-    else complain "runtime error: heap kaput"
+  if i < Option.heap_max then
+    let heap = IntMap.add i v heap in
+    (i, (heap, i + 1))
+  else
+    complain "runtime error: heap kaput"
 
 let deref (heap, _) a = IntMap.find a heap
 
 let assign (heap, i) a v =
-    let heap = IntMap.add a v heap
-    in (heap, i)
-
+  let heap = IntMap.add a v heap in
+  (heap, i)
 
 (* update : (env * binding) -> env *)
 (* let update(env, (x, v)) = (x, v) :: env *)
 
-let mk_fun(c, env) = CLOSURE(c, env)
-let mk_rec(f, c, env) = CLOSURE(c, (f, REC_CLOSURE(c))::env)
+let mk_fun (c, env) = CLOSURE (c, env)
+let mk_rec (f, c, env) = CLOSURE (c, (f, REC_CLOSURE c) :: env)
 
 (*
    in interp_0:
@@ -200,135 +197,141 @@ let rec lookup_opt = function
 let rec search (evs, x) =
   match evs with
   | [] -> complainf "%s is not defined!\n" x
-  | (V _) :: rest -> search (rest, x)
-  | (EV env) :: rest ->
-    (match lookup_opt(env, x) with
-    | None -> search (rest, x)
-    | Some v -> v
-    )
+  | V _ :: rest -> search (rest, x)
+  | EV env :: rest -> (
+      match lookup_opt (env, x) with None -> search (rest, x) | Some v -> v)
 
 let rec evs_to_env = function
- | [] -> []
- | (V _) :: rest -> evs_to_env rest
- | (EV env) :: rest -> env @ evs_to_env rest
+  | [] -> []
+  | V _ :: rest -> evs_to_env rest
+  | EV env :: rest -> env @ evs_to_env rest
 
-let readint () = let _ = print_string "input> " in read_int ()
+let readint () =
+  let _ = print_string "input> " in
+  read_int ()
 
 let do_unary = function
-  | (NOT,  BOOL m) -> BOOL (not m)
-  | (NEG,  INT m)  -> INT (-m)
-  | (READ, UNIT)   -> INT (readint())
-  | (op, _) -> complainf "malformed unary operator: %s" (string_of_unary_oper op)
+  | NOT, BOOL m -> BOOL (not m)
+  | NEG, INT m -> INT (-m)
+  | READ, UNIT -> INT (readint ())
+  | op, _ -> complainf "malformed unary operator: %s" (string_of_unary_oper op)
 
 let do_oper = function
-  | (AND,  BOOL m,  BOOL n) -> BOOL (m && n)
-  | (OR,   BOOL m,  BOOL n) -> BOOL (m || n)
-  | (EQB,  BOOL m,  BOOL n) -> BOOL (m = n)
-  | (LT,   INT m,   INT n)  -> BOOL (m < n)
-  | (EQI,  INT m,   INT n)  -> BOOL (m = n)
-  | (ADD,  INT m,   INT n)  -> INT (m + n)
-  | (SUB,  INT m,   INT n)  -> INT (m - n)
-  | (MUL,  INT m,   INT n)  -> INT (m * n)
-  | (DIV,  INT m,   INT n)  -> INT (m / n)
-  | (op, _, _)  -> complainf "malformed binary operator: %s" (string_of_oper op)
+  | AND, BOOL m, BOOL n -> BOOL (m && n)
+  | OR, BOOL m, BOOL n -> BOOL (m || n)
+  | EQB, BOOL m, BOOL n -> BOOL (m = n)
+  | LT, INT m, INT n -> BOOL (m < n)
+  | EQI, INT m, INT n -> BOOL (m = n)
+  | ADD, INT m, INT n -> INT (m + n)
+  | SUB, INT m, INT n -> INT (m - n)
+  | MUL, INT m, INT n -> INT (m * n)
+  | DIV, INT m, INT n -> INT (m / n)
+  | op, _, _ -> complainf "malformed binary operator: %s" (string_of_oper op)
 
 (*
     val step : interp_state -> interp_state
              = (code * env_value_stack * state) -> (code * env_value_stack * state)
 *)
 let step = function
-
-(* (code stack,         value/env stack, state) -> (code stack,  value/env stack, state) *)
- | ((PUSH v) :: ds,                        evs, s) -> (ds, V v :: evs, s)
- | (POP :: ds,                        _ :: evs, s) -> (ds, evs, s)
- | (SWAP:: ds,                e1 :: e2 :: evs, s) -> (ds, e2 :: e1 :: evs, s)
- | (BIND x :: ds,               V v :: evs, s) -> (ds, EV([(x, v)]) :: evs, s)
- | (LOOKUP x :: ds,                      evs, s) -> (ds, V(search(evs, x)) :: evs, s)
- | (UNARY op :: ds,             V v :: evs, s) -> (ds, V(do_unary(op, v)) :: evs, s)
- | (OPER op :: ds,   V v2 :: V v1 :: evs, s) -> (ds, V(do_oper(op, v1, v2)) :: evs, s)
- | (MK_PAIR :: ds,     V v2 :: V v1 :: evs, s) -> (ds, V(PAIR(v1, v2)) :: evs, s)
- | (FST :: ds,           V(PAIR (v, _)) :: evs, s) -> (ds, V v :: evs, s)
- | (SND :: ds,           V(PAIR (_, v)) :: evs, s) -> (ds, V v :: evs, s)
- | (MK_INL :: ds,                 V v :: evs, s) -> (ds, V (INL v) :: evs, s)
- | (MK_INR :: ds,                 V v :: evs, s) -> (ds, V (INR v) :: evs, s)
- | (CASE (c1,  _) :: ds,       V(INL v) :: evs, s) -> (c1 @ ds, V v :: evs, s)
- | (CASE (_, c2) :: ds,       V(INR v) :: evs, s) -> (c2 @ ds, V v :: evs, s)
- | (TEST(c1, _) :: ds,   V(BOOL true) :: evs, s) -> (c1 @ ds, evs, s)
- | (TEST(_, c2) :: ds,  V(BOOL false) :: evs, s) -> (c2 @ ds, evs, s)
- | (ASSIGN :: ds,  V v :: (V (REF a)) :: evs, s) -> (ds, V UNIT :: evs, assign s a v)
- | (DEREF :: ds,            (V (REF a)) :: evs, s) -> (ds, V(deref s a) :: evs, s)
- | (MK_REF :: ds,                 V v :: evs, s) -> let (a, s') = allocate s v in (ds, V (REF a) :: evs, s')
- | (WHILE (_, _) :: ds,  V(BOOL false) :: evs, s) -> (ds, V(UNIT) :: evs, s)
- | (WHILE (c1, c2) :: ds, V(BOOL true) :: evs, s) -> (c2 @ [POP] @ c1 @ [WHILE (c1, c2)] @ ds, evs, s)
- | (MK_CLOSURE c :: ds,                  evs, s) -> (ds,  V(mk_fun(c, evs_to_env evs)) :: evs, s)
- | (MK_REC (f, c) :: ds,                    evs, s) -> (ds,  V(mk_rec(f, c, evs_to_env evs)) :: evs, s)
- | (APPLY :: ds,  V(CLOSURE (c, env)) :: V v :: evs, s)
-                                                   -> (c @ ds, (V v) :: (EV env) :: evs, s)
- | state -> complainf "step : bad state = %a\n" pp_interp_state state
+  (* (code stack,         value/env stack, state) -> (code stack,  value/env stack, state) *)
+  | PUSH v :: ds, evs, s -> (ds, V v :: evs, s)
+  | POP :: ds, _ :: evs, s -> (ds, evs, s)
+  | SWAP :: ds, e1 :: e2 :: evs, s -> (ds, e2 :: e1 :: evs, s)
+  | BIND x :: ds, V v :: evs, s -> (ds, EV [ (x, v) ] :: evs, s)
+  | LOOKUP x :: ds, evs, s -> (ds, V (search (evs, x)) :: evs, s)
+  | UNARY op :: ds, V v :: evs, s -> (ds, V (do_unary (op, v)) :: evs, s)
+  | OPER op :: ds, V v2 :: V v1 :: evs, s ->
+      (ds, V (do_oper (op, v1, v2)) :: evs, s)
+  | MK_PAIR :: ds, V v2 :: V v1 :: evs, s -> (ds, V (PAIR (v1, v2)) :: evs, s)
+  | FST :: ds, V (PAIR (v, _)) :: evs, s -> (ds, V v :: evs, s)
+  | SND :: ds, V (PAIR (_, v)) :: evs, s -> (ds, V v :: evs, s)
+  | MK_INL :: ds, V v :: evs, s -> (ds, V (INL v) :: evs, s)
+  | MK_INR :: ds, V v :: evs, s -> (ds, V (INR v) :: evs, s)
+  | CASE (c1, _) :: ds, V (INL v) :: evs, s -> (c1 @ ds, V v :: evs, s)
+  | CASE (_, c2) :: ds, V (INR v) :: evs, s -> (c2 @ ds, V v :: evs, s)
+  | TEST (c1, _) :: ds, V (BOOL true) :: evs, s -> (c1 @ ds, evs, s)
+  | TEST (_, c2) :: ds, V (BOOL false) :: evs, s -> (c2 @ ds, evs, s)
+  | ASSIGN :: ds, V v :: V (REF a) :: evs, s -> (ds, V UNIT :: evs, assign s a v)
+  | DEREF :: ds, V (REF a) :: evs, s -> (ds, V (deref s a) :: evs, s)
+  | MK_REF :: ds, V v :: evs, s ->
+      let a, s' = allocate s v in
+      (ds, V (REF a) :: evs, s')
+  | WHILE (_, _) :: ds, V (BOOL false) :: evs, s -> (ds, V UNIT :: evs, s)
+  | WHILE (c1, c2) :: ds, V (BOOL true) :: evs, s ->
+      (c2 @ [ POP ] @ c1 @ [ WHILE (c1, c2) ] @ ds, evs, s)
+  | MK_CLOSURE c :: ds, evs, s -> (ds, V (mk_fun (c, evs_to_env evs)) :: evs, s)
+  | MK_REC (f, c) :: ds, evs, s ->
+      (ds, V (mk_rec (f, c, evs_to_env evs)) :: evs, s)
+  | APPLY :: ds, V (CLOSURE (c, env)) :: V v :: evs, s ->
+      (c @ ds, V v :: EV env :: evs, s)
+  | state -> complainf "step : bad state = %a\n" pp_interp_state state
 
 let rec driver n state =
-  let () = if Option.verbose
-           then Format.printf "\nState %d : %a@." n pp_interp_state state
-  in match state with
-     | ([], [V v], s) -> (v, s)
-     | _ -> driver (n + 1) (step state)
-
+  let () =
+    if Option.verbose then
+      Format.printf "\nState %d : %a@." n pp_interp_state state
+  in
+  match state with [], [ V v ], s -> (v, s) | _ -> driver (n + 1) (step state)
 
 (* A BIND will leave an env on stack.
    This gets rid of it.  *)
-let leave_scope = [SWAP; POP]
+let leave_scope = [ SWAP; POP ]
 
 (*
    val compile : expr -> code
 *)
 let rec compile = function
- | Unit           -> [PUSH UNIT]
- | Integer n      -> [PUSH (INT n)]
- | Boolean b      -> [PUSH (BOOL b)]
- | Var x          -> [LOOKUP x]
- | UnaryOp (op, e) -> compile e @ [UNARY op]
- | Op (e1, op, e2) -> compile e1 @ compile e2 @ [OPER op]
- | Pair (e1, e2)   -> compile e1 @ compile e2 @ [MK_PAIR]
- | Fst e          -> compile e @ [FST]
- | Snd e          -> compile e @ [SND]
- | Inl e          -> compile e @ [MK_INL]
- | Inr e          -> compile e @ [MK_INR]
- | Case (e, (x1, e1), (x2, e2)) ->
-       compile e
-       @ [CASE (BIND x1 :: compile e1 @ leave_scope,
-               (BIND x2) :: compile e2 @ leave_scope)]
- | If (e1, e2, e3) -> compile e1 @ [TEST(compile e2, compile e3)]
- | Seq []         -> []
- | Seq [e]        -> compile e
- (* Locations on sequence should highlight entire code blocks? *)
- | Seq (e ::rest) -> compile e @ [POP] @ compile (Seq rest)
- | Ref e          -> compile e @ [MK_REF]
- | Deref e        -> compile e @ [DEREF]
- | While (e1, e2)  -> let cl = compile e1 in cl @ [WHILE (cl, compile e2)]
- | Assign (e1, e2) -> compile e1 @ compile e2 @ [ASSIGN]
- | App (e1, e2)    -> compile e2   (* I chose to evaluate arg first *)
-                     @ compile e1
-                     @ [APPLY;
-                        SWAP; POP]  (* get rid of env left on stack *)
- | Lambda(x, e)   -> [MK_CLOSURE (BIND x :: compile e @ leave_scope)]
- | LetFun(f, (x, body), e)    ->
-       MK_CLOSURE (BIND x :: compile body @ leave_scope) ::
-       BIND f ::
-       compile e @ leave_scope
- | LetRecFun (f, (x, body), e) ->
-       MK_REC (f, (BIND x) :: compile body @ leave_scope) ::
-       BIND f ::
-       compile e @ leave_scope
-
+  | Unit -> [ PUSH UNIT ]
+  | Integer n -> [ PUSH (INT n) ]
+  | Boolean b -> [ PUSH (BOOL b) ]
+  | Var x -> [ LOOKUP x ]
+  | UnaryOp (op, e) -> compile e @ [ UNARY op ]
+  | Op (e1, op, e2) -> compile e1 @ compile e2 @ [ OPER op ]
+  | Pair (e1, e2) -> compile e1 @ compile e2 @ [ MK_PAIR ]
+  | Fst e -> compile e @ [ FST ]
+  | Snd e -> compile e @ [ SND ]
+  | Inl e -> compile e @ [ MK_INL ]
+  | Inr e -> compile e @ [ MK_INR ]
+  | Case (e, (x1, e1), (x2, e2)) ->
+      compile e
+      @ [
+          CASE
+            ( (BIND x1 :: compile e1) @ leave_scope,
+              (BIND x2 :: compile e2) @ leave_scope );
+        ]
+  | If (e1, e2, e3) -> compile e1 @ [ TEST (compile e2, compile e3) ]
+  | Seq [] -> []
+  | Seq [ e ] -> compile e
+  (* Locations on sequence should highlight entire code blocks? *)
+  | Seq (e :: rest) -> compile e @ [ POP ] @ compile (Seq rest)
+  | Ref e -> compile e @ [ MK_REF ]
+  | Deref e -> compile e @ [ DEREF ]
+  | While (e1, e2) ->
+      let cl = compile e1 in
+      cl @ [ WHILE (cl, compile e2) ]
+  | Assign (e1, e2) -> compile e1 @ compile e2 @ [ ASSIGN ]
+  | App (e1, e2) ->
+      compile e2 (* I chose to evaluate arg first *)
+      @ compile e1 @ [ APPLY; SWAP; POP ]
+      (* get rid of env left on stack *)
+  | Lambda (x, e) -> [ MK_CLOSURE ((BIND x :: compile e) @ leave_scope) ]
+  | LetFun (f, (x, body), e) ->
+      MK_CLOSURE ((BIND x :: compile body) @ leave_scope)
+      :: BIND f :: compile e
+      @ leave_scope
+  | LetRecFun (f, (x, body), e) ->
+      (MK_REC (f, (BIND x :: compile body) @ leave_scope) :: BIND f :: compile e)
+      @ leave_scope
 
 (* The initial Slang state is the Slang state : all locations contain 0 *)
 let initial_state = (IntMap.empty, 0)
-
 let initial_env = []
 
 (* interpret : expr -> (value * state) *)
 let interpret e =
   let c = compile e in
-  let () = if Option.verbose
-           then Format.printf "Compile code =@\n%a@." pp_code c in
+  let () =
+    if Option.verbose then
+      Format.printf "Compile code =@\n%a@." pp_code c
+  in
   driver 1 (c, initial_env, initial_state)

--- a/slang/interp_2.mli
+++ b/slang/interp_2.mli
@@ -2,22 +2,20 @@
 module IntMap : Map.S with type key = int
 
 type address = int
-
 type var = string
 
 type value =
-     | REF of address
-     | INT of int
-     | BOOL of bool
-     | UNIT
-     | PAIR of value * value
-     | INL of value
-     | INR of value
-     | CLOSURE of closure
-     | REC_CLOSURE of code
+  | REF of address
+  | INT of int
+  | BOOL of bool
+  | UNIT
+  | PAIR of value * value
+  | INL of value
+  | INR of value
+  | CLOSURE of closure
+  | REC_CLOSURE of code
 
 and closure = code * env
-
 
 and instruction =
   | PUSH of value
@@ -43,32 +41,22 @@ and instruction =
   | WHILE of code * code
 
 and code = instruction list
-
 and binding = Ast.var * value
-
 and env = binding list
 
 type env_or_value = EV of env | V of value
-
 type env_value_stack = env_or_value list
 
 (* array of referenced values together with next unallocated address *)
 type state = value IntMap.t * int
-
 type interp_state = code * env_value_stack * state
 
 val initial_state : state
-
 val initial_env : env_value_stack
-
-val step :  interp_state -> interp_state
-
+val step : interp_state -> interp_state
 val compile : Ast.expr -> code
-
 val driver : int -> interp_state -> value * state
-
 val interpret : Ast.expr -> value * state
-
 val string_of_instruction : instruction -> string
 val string_of_value : value -> string
 val string_of_env_or_value : env_or_value -> string

--- a/slang/interp_3.ml
+++ b/slang/interp_3.ml
@@ -15,26 +15,23 @@ Timothy G. Griffin (tgg22@cam.ac.uk)
    --- compiler elimnates WHILE construct
 *)
 
-
 open Ast
 open Errors
 
 type address = int
-
 type label = string
-
-type location = label * (address option)
+type location = label * address option
 
 type value =
-     | REF of address
-     | INT of int
-     | BOOL of bool
-     | UNIT
-     | PAIR of value * value
-     | INL of value
-     | INR of value
-     | CLOSURE of location * env
-     | REC_CLOSURE of location
+  | REF of address
+  | INT of int
+  | BOOL of bool
+  | UNIT
+  | PAIR of value * value
+  | INL of value
+  | INR of value
+  | CLOSURE of location * env
+  | REC_CLOSURE of location
 
 and instruction =
   | PUSH of value
@@ -63,112 +60,109 @@ and instruction =
   | HALT
 
 and code = instruction list
-
 and binding = var * value
-
 and env = binding list
 
 type env_or_value =
-  | EV of env        (* an environment on the run-time stack *)
-  | V of value       (* a value on the run-time stack *)
-  | RA of address    (* a return address on the run-time stack *)
+  | EV of env (* an environment on the run-time stack *)
+  | V of value (* a value on the run-time stack *)
+  | RA of address (* a return address on the run-time stack *)
 
 type env_value_stack = env_or_value list
-
 type state = address * env_value_stack
 
 (* update : (env * binding) -> env *)
 (* let update(env, (x, v)) = (x, v) :: env *)
 
 let rec lookup (env, x) =
-    match env with
-    | [] -> None
-    | (y, v) :: rest -> if x = y then Some(match v with
-        | REC_CLOSURE(loc) -> CLOSURE(loc, (y, REC_CLOSURE loc)::rest)
-        | _ -> v)
-      else lookup (rest, x)
+  match env with
+  | [] -> None
+  | (y, v) :: rest ->
+      if x = y then
+        Some
+          (match v with
+          | REC_CLOSURE loc -> CLOSURE (loc, (y, REC_CLOSURE loc) :: rest)
+          | _ -> v)
+      else
+        lookup (rest, x)
 
 let rec search (evs, x) =
   match evs with
   | [] -> complainf "%s is not defined!@\n" x
   | V _ :: rest -> search (rest, x)
   | RA _ :: rest -> search (rest, x)
-  | EV env :: rest ->
-    (match lookup (env, x) with
-    | None -> search (rest, x)
-    | Some v -> v)
- let rec evs_to_env = function
+  | EV env :: rest -> (
+      match lookup (env, x) with None -> search (rest, x) | Some v -> v)
+
+let rec evs_to_env = function
   | [] -> []
-  | (V _) :: rest -> evs_to_env rest
-  | (RA _) :: rest -> evs_to_env rest
-  | (EV env) :: rest -> env @ (evs_to_env rest)
+  | V _ :: rest -> evs_to_env rest
+  | RA _ :: rest -> evs_to_env rest
+  | EV env :: rest -> env @ evs_to_env rest
 
 let pr = Format.fprintf
 
 let pp_list fmt sep f l =
-   let rec aux f fmt = function
-     | [] -> ()
-     | [t] -> f fmt t
-     | t :: rest -> pr fmt "%a%(%)%a" f t sep (aux f) rest
-   in pr fmt "@[[%a]@]" (aux f) l
+  let rec aux f fmt = function
+    | [] -> ()
+    | [ t ] -> f fmt t
+    | t :: rest -> pr fmt "%a%(%)%a" f t sep (aux f) rest
+  in
+  pr fmt "@[[%a]@]" (aux f) l
 
 let rec pp_value fmt = function
-  | REF a            -> pr fmt "REF(%d)" a
-  | BOOL b           -> pr fmt "%b" b
-  | INT n            -> pr fmt "%d" n
-  | UNIT             -> pr fmt "UNIT"
-  | PAIR(v1, v2)     -> pr fmt "(@[%a,@ %a)@]" pp_value v1 pp_value v2
-  | INL v            -> pr fmt "inl(%a)" pp_value v
-  | INR  v           -> pr fmt "inr(%a)" pp_value v
+  | REF a -> pr fmt "REF(%d)" a
+  | BOOL b -> pr fmt "%b" b
+  | INT n -> pr fmt "%d" n
+  | UNIT -> pr fmt "UNIT"
+  | PAIR (v1, v2) -> pr fmt "(@[%a,@ %a)@]" pp_value v1 pp_value v2
+  | INL v -> pr fmt "inl(%a)" pp_value v
+  | INR v -> pr fmt "inr(%a)" pp_value v
   | CLOSURE (loc, c) -> pr fmt "CLOSURE(%a)" pp_closure (loc, c)
-  | REC_CLOSURE(loc) -> pr fmt "REC_CLOSURE(%a)" pp_location loc
+  | REC_CLOSURE loc -> pr fmt "REC_CLOSURE(%a)" pp_location loc
 
-and pp_closure fmt (loc, env) =
-  pr fmt "(%a, %a)" pp_location loc pp_env env
-
+and pp_closure fmt (loc, env) = pr fmt "(%a, %a)" pp_location loc pp_env env
 and pp_env fmt env = pp_list fmt ",@\n " pp_binding env
-
 and pp_binding fmt (x, v) = pr fmt "(%s, %a)" x pp_value v
 
 and pp_location fmt = function
-  | (l, None) -> pr fmt "%s" l
-  | (l, Some i) -> pr fmt "%s = %d" l i
+  | l, None -> pr fmt "%s" l
+  | l, Some i -> pr fmt "%s = %d" l i
 
 and pp_instruction fmt = function
- | UNARY op        -> pr fmt "  UNARY %s" (string_of_uop op)
- | OPER op         -> pr fmt "  OPER %s" (string_of_bop op)
- | MK_PAIR         -> pr fmt "  MK_PAIR"
- | FST             -> pr fmt "  FST"
- | SND             -> pr fmt "  SND"
- | MK_INL          -> pr fmt "  MK_INL"
- | MK_INR          -> pr fmt "  MK_INR"
- | MK_REF          -> pr fmt "  MK_REF"
- | PUSH v          -> pr fmt "  PUSH %a" pp_value v
- | LOOKUP x        -> pr fmt "  LOOKUP %s" x
- | TEST label      -> pr fmt "  TEST %a" pp_location label
- | CASE label      -> pr fmt "  CASE %a" pp_location label
- | GOTO label      -> pr fmt "  GOTO %a" pp_location label
- | APPLY           -> pr fmt "  APPLY"
- | RETURN          -> pr fmt "  RETURN"
- | HALT            -> pr fmt "  HALT"
- | BIND x          -> pr fmt "  BIND %s" x
- | LABEL label     -> pr fmt "LABEL %s:" label
- | SWAP            -> pr fmt "  SWAP"
- | POP             -> pr fmt "  POP"
- | DEREF           -> pr fmt "  DEREF"
- | ASSIGN          -> pr fmt "  ASSIGN"
- | MK_CLOSURE loc  -> pr fmt "  MK_CLOSURE(%a)" pp_location loc
- | MK_REC (v, loc) -> pr fmt "  MK_REC(@[%s, %a)@]" v pp_location loc
+  | UNARY op -> pr fmt "  UNARY %s" (string_of_uop op)
+  | OPER op -> pr fmt "  OPER %s" (string_of_bop op)
+  | MK_PAIR -> pr fmt "  MK_PAIR"
+  | FST -> pr fmt "  FST"
+  | SND -> pr fmt "  SND"
+  | MK_INL -> pr fmt "  MK_INL"
+  | MK_INR -> pr fmt "  MK_INR"
+  | MK_REF -> pr fmt "  MK_REF"
+  | PUSH v -> pr fmt "  PUSH %a" pp_value v
+  | LOOKUP x -> pr fmt "  LOOKUP %s" x
+  | TEST label -> pr fmt "  TEST %a" pp_location label
+  | CASE label -> pr fmt "  CASE %a" pp_location label
+  | GOTO label -> pr fmt "  GOTO %a" pp_location label
+  | APPLY -> pr fmt "  APPLY"
+  | RETURN -> pr fmt "  RETURN"
+  | HALT -> pr fmt "  HALT"
+  | BIND x -> pr fmt "  BIND %s" x
+  | LABEL label -> pr fmt "LABEL %s:" label
+  | SWAP -> pr fmt "  SWAP"
+  | POP -> pr fmt "  POP"
+  | DEREF -> pr fmt "  DEREF"
+  | ASSIGN -> pr fmt "  ASSIGN"
+  | MK_CLOSURE loc -> pr fmt "  MK_CLOSURE(%a)" pp_location loc
+  | MK_REC (v, loc) -> pr fmt "  MK_REC(@[%s, %a)@]" v pp_location loc
 
 and pp_code fmt c = List.iter (pr fmt "%a@\n" pp_instruction) c
 
 let pp_env_or_value fmt = function
   | EV env -> pr fmt "EV %a" pp_env env
-  | V v    -> pr fmt "V %a" pp_value v
-  | RA i   -> pr fmt "RA %d" i
+  | V v -> pr fmt "V %a" pp_value v
+  | RA i -> pr fmt "RA %d" i
 
 let pp_env_value_stack fmt = pp_list fmt ";@\n " pp_env_or_value
-
 let string_of_value = Format.asprintf "%a" pp_value
 let string_of_location = Format.asprintf "%a" pp_location
 let string_of_code = Format.asprintf "%a" pp_code
@@ -176,168 +170,206 @@ let string_of_env_or_value = Format.asprintf "%a" pp_env_or_value
 
 (* THE MACHINE *)
 
-let installed = ref (Array.of_list [HALT])
+let installed = ref (Array.of_list [ HALT ])
 
 let pp_installed_code fmt =
   let size = Array.length !installed in
   let rec aux fmt k =
-    if size <> k
-    then pr fmt "%d: %a@\n%a" k pp_instruction !installed.(k) aux (k+1)
-  in aux fmt 0
+    if size <> k then
+      pr fmt "%d: %a@\n%a" k pp_instruction !installed.(k) aux (k + 1)
+  in
+  aux fmt 0
 
-let string_of_installed_code () = Format.asprintf "%a"
-                                    (fun f () -> pp_installed_code f) ()
+let string_of_installed_code () =
+  Format.asprintf "%a" (fun f () -> pp_installed_code f) ()
 
 let get_instruction cp = Array.get !installed cp
-
-let heap  = Array.make Option.heap_max (INT 0)
-
+let heap = Array.make Option.heap_max (INT 0)
 let next_address = ref 0
 
-let new_address () = let a = !next_address in (next_address := a + 1; a)
+let new_address () =
+  let a = !next_address in
+  next_address := a + 1;
+  a
 
-let string_of_heap ()  =
+let string_of_heap () =
   let rec aux k =
-    if !next_address < k
-    then ""
-    else string_of_int k ^ " -> " ^ string_of_value (heap.(k)) ^ "\n" ^ aux (k+1)
-  in "\nHeap = \n" ^ aux 0
+    if !next_address < k then
+      ""
+    else
+      string_of_int k ^ " -> " ^ string_of_value heap.(k) ^ "\n" ^ aux (k + 1)
+  in
+  "\nHeap = \n" ^ aux 0
 
 let pp_state fmt (cp, evs) =
-  pr fmt "@\nCode Pointer = %d -> %a@\nStack = %a%s@\n"
-    cp pp_instruction (get_instruction cp) pp_env_value_stack evs
-    (if !next_address = 0 then "" else string_of_heap ())
+  pr fmt "@\nCode Pointer = %d -> %a@\nStack = %a%s@\n" cp pp_instruction
+    (get_instruction cp) pp_env_value_stack evs
+    (if !next_address = 0 then
+       ""
+     else
+       string_of_heap ())
 
-let readint () = let _ = print_string "input> " in read_int()
+let readint () =
+  let _ = print_string "input> " in
+  read_int ()
 
 let do_unary = function
-  | (NOT,  BOOL m) -> BOOL (not m)
-  | (NEG,  INT m)  -> INT (-m)
-  | (READ, UNIT)   -> INT (readint())
-  | (op, _) -> complainf "malformed unary operator: %s" (string_of_unary_oper op)
+  | NOT, BOOL m -> BOOL (not m)
+  | NEG, INT m -> INT (-m)
+  | READ, UNIT -> INT (readint ())
+  | op, _ -> complainf "malformed unary operator: %s" (string_of_unary_oper op)
 
 let do_oper = function
-  | (AND,  BOOL m,  BOOL n) -> BOOL (m && n)
-  | (OR,   BOOL m,  BOOL n) -> BOOL (m || n)
-  | (EQB,  BOOL m,  BOOL n) -> BOOL (m = n)
-  | (LT,   INT m,   INT n)  -> BOOL (m < n)
-  | (EQI,  INT m,   INT n)  -> BOOL (m = n)
-  | (ADD,  INT m,   INT n)  -> INT (m + n)
-  | (SUB,  INT m,   INT n)  -> INT (m - n)
-  | (MUL,  INT m,   INT n)  -> INT (m * n)
-  | (DIV,  INT m,   INT n)  -> INT (m / n)
-  | (op, _, _)  -> complainf "malformed binary operator: %s" (string_of_oper op)
-
+  | AND, BOOL m, BOOL n -> BOOL (m && n)
+  | OR, BOOL m, BOOL n -> BOOL (m || n)
+  | EQB, BOOL m, BOOL n -> BOOL (m = n)
+  | LT, INT m, INT n -> BOOL (m < n)
+  | EQI, INT m, INT n -> BOOL (m = n)
+  | ADD, INT m, INT n -> INT (m + n)
+  | SUB, INT m, INT n -> INT (m - n)
+  | MUL, INT m, INT n -> INT (m * n)
+  | DIV, INT m, INT n -> INT (m / n)
+  | op, _, _ -> complainf "malformed binary operator: %s" (string_of_oper op)
 
 let step (cp, evs) =
- match (get_instruction cp, evs) with
- | (PUSH v,                            evs) -> (cp + 1, V v :: evs)
- | (POP,                          _ :: evs) -> (cp + 1, evs)
- | (SWAP,                  s1 :: s2 :: evs) -> (cp + 1, s2 :: s1 :: evs)
- | (BIND x,                   (V v) :: evs) -> (cp + 1, EV([(x, v)]) :: evs)
- | (LOOKUP x,                          evs) -> (cp + 1, V (search (evs, x)) :: evs)
- | (UNARY op,                 (V v) :: evs) -> (cp + 1, V (do_unary (op, v)) :: evs)
- | (OPER op,       (V v2) :: (V v1) :: evs) -> (cp + 1, V (do_oper (op, v1, v2)) :: evs)
- | (MK_PAIR,       (V v2) :: (V v1) :: evs) -> (cp + 1, V(PAIR(v1, v2)) :: evs)
- | (FST,             V(PAIR (v, _)) :: evs) -> (cp + 1, V v :: evs)
- | (SND,             V(PAIR (_, v)) :: evs) -> (cp + 1, V v :: evs)
- | (MK_INL,                   (V v) :: evs) -> (cp + 1, V (INL v) :: evs)
- | (MK_INR,                   (V v) :: evs) -> (cp + 1, V (INR v) :: evs)
- | (CASE (_, Some _),        V(INL v)::evs) -> (cp + 1, V v :: evs)
- | (CASE (_, Some i),        V(INR v)::evs) -> (i,      V v :: evs)
- | (TEST (_, Some _),  V(BOOL true) :: evs) -> (cp + 1, evs)
- | (TEST (_, Some i), V(BOOL false) :: evs) -> (i,      evs)
- | (ASSIGN,    (V v) :: (V (REF a)) :: evs) -> (heap.(a) <- v; (cp + 1, V UNIT :: evs))
- | (DEREF,              (V (REF a)) :: evs) -> (cp + 1, V (heap.(a)) :: evs)
- | (MK_REF,                   (V v) :: evs) -> let a = new_address () in (heap.(a) <- v;
-                                               (cp + 1, V(REF a) :: evs))
- | (MK_CLOSURE loc,                    evs) -> (cp + 1, V(CLOSURE(loc, evs_to_env evs)) :: evs)
- | (MK_REC (f, loc),                   evs) -> (cp + 1, V(CLOSURE(loc, (f, REC_CLOSURE loc):: evs_to_env evs)) :: evs)
- | (APPLY,  V(CLOSURE ((_,Some i), env)) :: V v :: evs)
-                                            -> (i, V v :: EV env :: RA (cp + 1) :: evs)
-(* new intructions *)
- | (RETURN,    (V v) :: _ :: (RA i) :: evs) -> (i, V v :: evs)
- | (LABEL (_),                           evs) -> (cp + 1, evs)
- | (HALT,                              evs) -> (cp, evs)
- | (GOTO (_, Some i),                  evs) -> (i, evs)
- | _ -> complainf "step : bad state = %a\n" pp_state (cp, evs)
+  match (get_instruction cp, evs) with
+  | PUSH v, evs -> (cp + 1, V v :: evs)
+  | POP, _ :: evs -> (cp + 1, evs)
+  | SWAP, s1 :: s2 :: evs -> (cp + 1, s2 :: s1 :: evs)
+  | BIND x, V v :: evs -> (cp + 1, EV [ (x, v) ] :: evs)
+  | LOOKUP x, evs -> (cp + 1, V (search (evs, x)) :: evs)
+  | UNARY op, V v :: evs -> (cp + 1, V (do_unary (op, v)) :: evs)
+  | OPER op, V v2 :: V v1 :: evs -> (cp + 1, V (do_oper (op, v1, v2)) :: evs)
+  | MK_PAIR, V v2 :: V v1 :: evs -> (cp + 1, V (PAIR (v1, v2)) :: evs)
+  | FST, V (PAIR (v, _)) :: evs -> (cp + 1, V v :: evs)
+  | SND, V (PAIR (_, v)) :: evs -> (cp + 1, V v :: evs)
+  | MK_INL, V v :: evs -> (cp + 1, V (INL v) :: evs)
+  | MK_INR, V v :: evs -> (cp + 1, V (INR v) :: evs)
+  | CASE (_, Some _), V (INL v) :: evs -> (cp + 1, V v :: evs)
+  | CASE (_, Some i), V (INR v) :: evs -> (i, V v :: evs)
+  | TEST (_, Some _), V (BOOL true) :: evs -> (cp + 1, evs)
+  | TEST (_, Some i), V (BOOL false) :: evs -> (i, evs)
+  | ASSIGN, V v :: V (REF a) :: evs ->
+      heap.(a) <- v;
+      (cp + 1, V UNIT :: evs)
+  | DEREF, V (REF a) :: evs -> (cp + 1, V heap.(a) :: evs)
+  | MK_REF, V v :: evs ->
+      let a = new_address () in
+      heap.(a) <- v;
+      (cp + 1, V (REF a) :: evs)
+  | MK_CLOSURE loc, evs -> (cp + 1, V (CLOSURE (loc, evs_to_env evs)) :: evs)
+  | MK_REC (f, loc), evs ->
+      (cp + 1, V (CLOSURE (loc, (f, REC_CLOSURE loc) :: evs_to_env evs)) :: evs)
+  | APPLY, V (CLOSURE ((_, Some i), env)) :: V v :: evs ->
+      (i, V v :: EV env :: RA (cp + 1) :: evs)
+  (* new intructions *)
+  | RETURN, V v :: _ :: RA i :: evs -> (i, V v :: evs)
+  | LABEL _, evs -> (cp + 1, evs)
+  | HALT, evs -> (cp, evs)
+  | GOTO (_, Some i), evs -> (i, evs)
+  | _ -> complainf "step : bad state = %a\n" pp_state (cp, evs)
 
 (* COMPILE *)
 
 let label_ref = ref 0
+
 let new_label =
-  let get () = let v = !label_ref in (label_ref := (!label_ref) + 1; "L"^ (string_of_int v))
-  in get
+  let get () =
+    let v = !label_ref in
+    label_ref := !label_ref + 1;
+    "L" ^ string_of_int v
+  in
+  get
 
 let rec comp = function
-  | Unit             -> ([], [PUSH UNIT])
-  | Integer n      -> ([], [PUSH (INT n)])
-  | Boolean b      -> ([], [PUSH (BOOL b)])
-  | Var x          -> ([], [LOOKUP x])
-  | UnaryOp (op, e) -> let (defs, c) = comp e in  (defs, c @ [UNARY op])
-  | Op (e1, op, e2) -> let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                          (defs1 @ defs2, c1 @ c2 @ [OPER op])
-  | Pair (e1, e2)   -> let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                          (defs1 @ defs2, c1 @ c2 @ [MK_PAIR])
-  | Fst e          -> let (defs, c) = comp e in (defs, c @ [FST])
-  | Snd e          -> let (defs, c) = comp e in (defs, c @ [SND])
-  | Inl e          -> let (defs, c) = comp e in (defs, c @ [MK_INL])
-  | Inr e          -> let (defs, c) = comp e in (defs, c @ [MK_INR])
+  | Unit -> ([], [ PUSH UNIT ])
+  | Integer n -> ([], [ PUSH (INT n) ])
+  | Boolean b -> ([], [ PUSH (BOOL b) ])
+  | Var x -> ([], [ LOOKUP x ])
+  | UnaryOp (op, e) ->
+      let defs, c = comp e in
+      (defs, c @ [ UNARY op ])
+  | Op (e1, op, e2) ->
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      (defs1 @ defs2, c1 @ c2 @ [ OPER op ])
+  | Pair (e1, e2) ->
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      (defs1 @ defs2, c1 @ c2 @ [ MK_PAIR ])
+  | Fst e ->
+      let defs, c = comp e in
+      (defs, c @ [ FST ])
+  | Snd e ->
+      let defs, c = comp e in
+      (defs, c @ [ SND ])
+  | Inl e ->
+      let defs, c = comp e in
+      (defs, c @ [ MK_INL ])
+  | Inr e ->
+      let defs, c = comp e in
+      (defs, c @ [ MK_INR ])
   | Case (e1, (x1, e2), (x2, e3)) ->
-                      let inr_label = new_label () in
-                      let after_inr_label = new_label () in
-                      let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                      let (defs3, c3) = comp e3 in
-                         (defs1 @ defs2 @ defs3,
-                          (c1
-   		           @ [CASE (inr_label, None)]
-                           @ (BIND x1 :: c2 @ [SWAP; POP])
-		           @ [GOTO (after_inr_label, None); LABEL inr_label]
-                           @ (BIND x2 :: c3 @ [SWAP; POP])
-		           @ [LABEL after_inr_label]))
-  | If (e1, e2, e3) -> let else_label = new_label () in
-                      let after_else_label = new_label () in
-                      let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                      let (defs3, c3) = comp e3 in
-                         (defs1 @ defs2 @ defs3,
-                          (c1
-   		           @ [TEST (else_label, None)]
-                           @ c2
-		           @ [GOTO (after_else_label, None); LABEL else_label]
-                           @ c3
-		           @ [LABEL after_else_label]))
- | Seq []         -> ([], [])
- | Seq [e]        -> comp e
- | Seq (e ::rest) -> let (defs1, c1) = comp e in
-                     let (defs2, c2) = comp (Seq rest) in
-                       (defs1 @ defs2, c1 @ [POP] @ c2)
- | Ref e          -> let (defs, c) = comp e in (defs, c @ [MK_REF])
- | Deref e        -> let (defs, c) = comp e in (defs, c @ [DEREF])
- | While (e1, e2)  -> let test_label = new_label () in
-                     let end_label = new_label () in
-                     let (defs1, c1) = comp e1 in
-                     let (defs2, c2) = comp e2 in
-                         (defs1 @ defs2,
-                          [LABEL test_label]
-                           @ c1
-                           @ [TEST (end_label, None)]
-                           @ c2
-                           @ [POP; GOTO (test_label, None); LABEL end_label; PUSH UNIT])
- | Assign (e1, e2) -> let (defs1, c1) = comp e1 in
-                     let (defs2, c2) = comp e2 in
-                         (defs1 @ defs2, c1 @ c2 @ [ASSIGN])
- | App (e1, e2)    -> let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                          (defs1 @ defs2, c2 @ c1 @ [APPLY])
- | Lambda (x, e)    -> let (defs, c) = comp e in
-                      let f = new_label () in
-                      let def = [LABEL f ; BIND x] @ c @ [SWAP; POP; RETURN] in
-                          (def @ defs, [MK_CLOSURE(f, None)])
-(*
+      let inr_label = new_label () in
+      let after_inr_label = new_label () in
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      let defs3, c3 = comp e3 in
+      ( defs1 @ defs2 @ defs3,
+        c1
+        @ [ CASE (inr_label, None) ]
+        @ ((BIND x1 :: c2) @ [ SWAP; POP ])
+        @ [ GOTO (after_inr_label, None); LABEL inr_label ]
+        @ ((BIND x2 :: c3) @ [ SWAP; POP ])
+        @ [ LABEL after_inr_label ] )
+  | If (e1, e2, e3) ->
+      let else_label = new_label () in
+      let after_else_label = new_label () in
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      let defs3, c3 = comp e3 in
+      ( defs1 @ defs2 @ defs3,
+        c1
+        @ [ TEST (else_label, None) ]
+        @ c2
+        @ [ GOTO (after_else_label, None); LABEL else_label ]
+        @ c3 @ [ LABEL after_else_label ] )
+  | Seq [] -> ([], [])
+  | Seq [ e ] -> comp e
+  | Seq (e :: rest) ->
+      let defs1, c1 = comp e in
+      let defs2, c2 = comp (Seq rest) in
+      (defs1 @ defs2, c1 @ [ POP ] @ c2)
+  | Ref e ->
+      let defs, c = comp e in
+      (defs, c @ [ MK_REF ])
+  | Deref e ->
+      let defs, c = comp e in
+      (defs, c @ [ DEREF ])
+  | While (e1, e2) ->
+      let test_label = new_label () in
+      let end_label = new_label () in
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      ( defs1 @ defs2,
+        [ LABEL test_label ] @ c1
+        @ [ TEST (end_label, None) ]
+        @ c2
+        @ [ POP; GOTO (test_label, None); LABEL end_label; PUSH UNIT ] )
+  | Assign (e1, e2) ->
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      (defs1 @ defs2, c1 @ c2 @ [ ASSIGN ])
+  | App (e1, e2) ->
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      (defs1 @ defs2, c2 @ c1 @ [ APPLY ])
+  | Lambda (x, e) ->
+      let defs, c = comp e in
+      let f = new_label () in
+      let def = [ LABEL f; BIND x ] @ c @ [ SWAP; POP; RETURN ] in
+      (def @ defs, [ MK_CLOSURE (f, None) ])
+  (*
  Note that we could have
 
  | LetFun(f, (x, e1), e2) -> comp (App(Lambda(f, e2), Lambda(x, e1)))
@@ -360,70 +392,88 @@ let rec comp = function
   which is simpler.
 
 *)
- | LetFun(f, (x, e1), e2) ->
-                      let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                      let lab = new_label () in
-                      let def = [LABEL lab; BIND x] @ c1 @ [SWAP; POP; RETURN] in
-                          (def @ defs1 @ defs2,
-                           [MK_CLOSURE (lab, None); BIND f] @ c2 @ [SWAP; POP])
- | LetRecFun(f, (x, e1), e2) ->
-                      let (defs1, c1) = comp e1 in
-                      let (defs2, c2) = comp e2 in
-                      let lab = new_label () in
-                      let def = [LABEL lab; BIND x] @ c1 @ [SWAP; POP; RETURN] in
-                          (def @ defs1 @ defs2,
-                           [MK_REC (f, (lab, None)); BIND f] @ c2 @ [SWAP; POP])
+  | LetFun (f, (x, e1), e2) ->
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      let lab = new_label () in
+      let def = [ LABEL lab; BIND x ] @ c1 @ [ SWAP; POP; RETURN ] in
+      ( def @ defs1 @ defs2,
+        [ MK_CLOSURE (lab, None); BIND f ] @ c2 @ [ SWAP; POP ] )
+  | LetRecFun (f, (x, e1), e2) ->
+      let defs1, c1 = comp e1 in
+      let defs2, c2 = comp e2 in
+      let lab = new_label () in
+      let def = [ LABEL lab; BIND x ] @ c1 @ [ SWAP; POP; RETURN ] in
+      ( def @ defs1 @ defs2,
+        [ MK_REC (f, (lab, None)); BIND f ] @ c2 @ [ SWAP; POP ] )
+
 let compile e =
-  let (defs, c) = comp e in
+  let defs, c = comp e in
   (* The HALT instruction needs an annotation to satisfy the types
      We arbitarily use the annotation from the root of the AST
    *)
-  let result = c             (* body of program *)
-             @ [HALT]        (* stop the interpreter *)
-             @ defs in       (* the function definitions *)
-  let () = if Option.verbose
-           then Format.printf "@\nCompiled Code = @\n%a" pp_code result
-  in result
+  let result =
+    c (* body of program *) @ [ HALT ] (* stop the interpreter *) @ defs
+  in
+  (* the function definitions *)
+  let () =
+    if Option.verbose then
+      Format.printf "@\nCompiled Code = @\n%a" pp_code result
+  in
+  result
 
-let rec driver n (cp, evs as state) =
-  (if Option.verbose then Format.printf "\nstate %d:%a\n" n pp_state state);
-  match get_instruction cp, evs with
-  | HALT, [V v] -> v
-  | HALT, _     -> complainf "driver : bad halted state = %a\n" pp_state state
-  | _           -> driver (n + 1) (step state)
+let rec driver n ((cp, evs) as state) =
+  if Option.verbose then
+    Format.printf "\nstate %d:%a\n" n pp_state state;
+  match (get_instruction cp, evs) with
+  | HALT, [ V v ] -> v
+  | HALT, _ -> complainf "driver : bad halted state = %a\n" pp_state state
+  | _ -> driver (n + 1) (step state)
 
 (* put code listing into an array, associate an array index to each label *)
 let load l =
   let rec find lab = function
-    | []             -> complainf "find : %s is not found" lab
-    | (x, v) :: rest -> if x = lab then v else find lab rest
-  (* insert array index for each label *) in
+    | [] -> complainf "find : %s is not found" lab
+    | (x, v) :: rest ->
+        if x = lab then
+          v
+        else
+          find lab rest
+    (* insert array index for each label *)
+  in
   let apply_label_map_to_instruction m = function
-    | GOTO (lab, _)        -> GOTO (lab, Some (find lab m))
-    | TEST (lab, _)        -> TEST (lab, Some (find lab m))
-    | CASE (lab, _)        -> CASE (lab, Some (find lab m))
-    | MK_CLOSURE (lab, _)  -> MK_CLOSURE (lab, Some (find lab m))
-    | MK_REC (f, (lab, _)) -> MK_REC(f, (lab, Some (find lab m)))
-    | inst                 -> inst in
-   (* find array index for each label *)
+    | GOTO (lab, _) -> GOTO (lab, Some (find lab m))
+    | TEST (lab, _) -> TEST (lab, Some (find lab m))
+    | CASE (lab, _) -> CASE (lab, Some (find lab m))
+    | MK_CLOSURE (lab, _) -> MK_CLOSURE (lab, Some (find lab m))
+    | MK_REC (f, (lab, _)) -> MK_REC (f, (lab, Some (find lab m)))
+    | inst -> inst
+  in
+  (* find array index for each label *)
   let listing_to_label_map l =
     let rec aux carry k = function
-      | []                -> carry
-      | LABEL lab :: rest -> aux ((lab, k) :: carry) (k+1) rest
-      | _ :: rest         -> aux carry (k+1) rest
-    in aux [] 0 l
-  in let l_map = listing_to_label_map l
-     in Array.of_list (List.map (apply_label_map_to_instruction l_map) l)
-
+      | [] -> carry
+      | LABEL lab :: rest -> aux ((lab, k) :: carry) (k + 1) rest
+      | _ :: rest -> aux carry (k + 1) rest
+    in
+    aux [] 0 l
+  in
+  let l_map = listing_to_label_map l in
+  Array.of_list (List.map (apply_label_map_to_instruction l_map) l)
 
 (* interpret : expr -> value *)
 let interpret e =
   let c = compile e in
   let () = installed := load c in
-  let () = if Option.verbose
-           then Format.printf "\nInstalled Code = \n%s" (string_of_installed_code ()) in
+  let () =
+    if Option.verbose then
+      Format.printf "\nInstalled Code = \n%s" (string_of_installed_code ())
+  in
   (* set the code pointer to 0 *)
-  driver 1 (0 , [])
+  driver 1 (0, [])
 
-let reset = fun () -> next_address := 0; label_ref := 0; Array.fill heap 0 (Array.length heap) (INT 0)
+let reset =
+ fun () ->
+  next_address := 0;
+  label_ref := 0;
+  Array.fill heap 0 (Array.length heap) (INT 0)

--- a/slang/interp_3.mli
+++ b/slang/interp_3.mli
@@ -1,9 +1,6 @@
-
 type address = int
-
 type label = string
-
-type location = label * (address option)
+type location = label * address option
 
 type value =
   | REF of address
@@ -43,49 +40,34 @@ and instruction =
   | HALT
 
 and code = instruction list
-
 and binding = Ast.var * value
-
 and env = binding list
 
 type env_or_value =
-  | EV of env           (* an environment on the run-time stack *)
-  | V of value          (* a value on the run-time stack *)
-  | RA of address    (* a return address on the run-time stack *)
+  | EV of env (* an environment on the run-time stack *)
+  | V of value (* a value on the run-time stack *)
+  | RA of address (* a return address on the run-time stack *)
 
 type env_value_stack = env_or_value list
-
 type state = address * env_value_stack
 
-val installed : (instruction array) ref
-
+val installed : instruction array ref
 val load : instruction list -> instruction array
-
 val step : state -> state
-
 val compile : Ast.expr -> code
-
 val heap : value array
-
 val next_address : address ref
-
 val driver : int -> state -> value
-
 val get_instruction : address -> instruction
-
 val interpret : Ast.expr -> value
-
 val pp_code : Format.formatter -> code -> unit
 val pp_value : Format.formatter -> value -> unit
 val pp_env_or_value : Format.formatter -> env_or_value -> unit
 val pp_installed_code : Format.formatter -> unit
 val pp_location : Format.formatter -> location -> unit
-
 val string_of_code : code -> string
 val string_of_value : value -> string
 val string_of_env_or_value : env_or_value -> string
 val string_of_installed_code : unit -> string
 val string_of_location : location -> string
-
 val reset : unit -> unit
-

--- a/slang/jargon.ml
+++ b/slang/jargon.ml
@@ -1,14 +1,12 @@
-
 open Ast
 
 type code_index = int
 type stack_index = int
 type heap_index = int
 type static_distance = int
-type offset  = int
-
+type offset = int
 type label = string
-type location = label * (code_index option)
+type location = label * code_index option
 
 type status_code =
   | Halted
@@ -22,39 +20,31 @@ type stack_item =
   | STACK_INT of int
   | STACK_BOOL of bool
   | STACK_UNIT
-  | STACK_HI of heap_index    (* Pointer into Heap            *)
-  | STACK_RA of code_index    (* return address               *)
-  | STACK_FP of stack_index   (* Frame pointer                *)
+  | STACK_HI of heap_index (* Pointer into Heap            *)
+  | STACK_RA of code_index (* return address               *)
+  | STACK_FP of stack_index (* Frame pointer                *)
 
-
-type heap_type =
-  | HT_PAIR
-  | HT_INL
-  | HT_INR
-  | HT_CLOSURE
+type heap_type = HT_PAIR | HT_INL | HT_INR | HT_CLOSURE
 
 type heap_item =
   | HEAP_INT of int
   | HEAP_BOOL of bool
   | HEAP_UNIT
-  | HEAP_HI of heap_index    (* Pointer into Heap            *)
-  | HEAP_CI of code_index    (* Code pointer for closures    *)
+  | HEAP_HI of heap_index (* Pointer into Heap            *)
+  | HEAP_CI of code_index (* Code pointer for closures    *)
   | HEAP_HEADER of int * heap_type (* int is number of items to follow *)
 
-
-type value_path =
-  | STACK_LOCATION of offset
-  | HEAP_LOCATION of offset
+type value_path = STACK_LOCATION of offset | HEAP_LOCATION of offset
 
 type instruction =
-  | PUSH of stack_item    (* modified *)
-  | LOOKUP of value_path  (* modified *)
+  | PUSH of stack_item (* modified *)
+  | LOOKUP of value_path (* modified *)
   | UNARY of unary_oper
   | OPER of oper
   | ASSIGN
   | SWAP
   | POP
-(*  | BIND of var            not needed *)
+  (*  | BIND of var            not needed *)
   | FST
   | SND
   | DEREF
@@ -73,23 +63,21 @@ type instruction =
 
 type listing = instruction list
 
-type vm_state =
-  {
-    stack_bound : stack_index;
-    code_bound  : code_index;
-    heap_bound  : code_index;
-    stack       : stack_item array;
-    heap        : heap_item array;
-    code        : instruction array;
-    mutable sp : stack_index;  (* stack pointer *)
-    mutable fp : stack_index;  (* frame pointer *)
-    mutable cp : code_index;   (* code pointer  *)
-    mutable hp : heap_index;   (* next free     *)
-    mutable status : status_code;
-  }
+type vm_state = {
+  stack_bound : stack_index;
+  code_bound : code_index;
+  heap_bound : code_index;
+  stack : stack_item array;
+  heap : heap_item array;
+  code : instruction array;
+  mutable sp : stack_index; (* stack pointer *)
+  mutable fp : stack_index; (* frame pointer *)
+  mutable cp : code_index; (* code pointer  *)
+  mutable hp : heap_index; (* next free     *)
+  mutable status : status_code;
+}
 
 let get_instruction vm = Array.get vm.code vm.cp
-
 let stack_top vm = Array.get vm.stack (vm.sp - 1)
 
 (********************** Printing ********************************)
@@ -102,145 +90,168 @@ let stack_top vm = Array.get vm.stack (vm.sp - 1)
    in "[" ^ (aux f l) ^ "]" *)
 
 let string_of_status = function
-  | Halted               -> "halted"
-  | Running              -> "running"
-  | CodeIndexOutOfBound  -> "code index out-of-bound"
+  | Halted -> "halted"
+  | Running -> "running"
+  | CodeIndexOutOfBound -> "code index out-of-bound"
   | StackIndexOutOfBound -> "stack index out-of-bound"
-  | HeapIndexOutOfBound  -> "heap index out-of-bound"
-  | StackUnderflow       -> "stack underflow"
+  | HeapIndexOutOfBound -> "heap index out-of-bound"
+  | StackUnderflow -> "stack underflow"
 
 let string_of_stack_item = function
-  | STACK_INT i      -> "STACK_INT " ^ (string_of_int i)
-  | STACK_BOOL true  -> "STACK_BOOL true"
+  | STACK_INT i -> "STACK_INT " ^ string_of_int i
+  | STACK_BOOL true -> "STACK_BOOL true"
   | STACK_BOOL false -> "STACK_BOOL false"
-  | STACK_UNIT       -> "STACK_UNIT"
-  | STACK_HI i       -> "STACK_HI " ^ (string_of_int i)
-  | STACK_RA i       -> "STACK_RA " ^ (string_of_int i)
-  | STACK_FP i       -> "STACK_FP " ^ (string_of_int i)
+  | STACK_UNIT -> "STACK_UNIT"
+  | STACK_HI i -> "STACK_HI " ^ string_of_int i
+  | STACK_RA i -> "STACK_RA " ^ string_of_int i
+  | STACK_FP i -> "STACK_FP " ^ string_of_int i
 
 let string_of_heap_type = function
-    | HT_PAIR    -> "HT_PAIR"
-    | HT_INL     -> "HT_INL"
-    | HT_INR     -> "HT_INR"
-    | HT_CLOSURE -> "HT_CLOSURE"
-
+  | HT_PAIR -> "HT_PAIR"
+  | HT_INL -> "HT_INL"
+  | HT_INR -> "HT_INR"
+  | HT_CLOSURE -> "HT_CLOSURE"
 
 let string_of_heap_item = function
-  | HEAP_INT i      -> "HEAP_INT " ^ (string_of_int i)
-  | HEAP_BOOL true  -> "HEAP_BOOL true"
+  | HEAP_INT i -> "HEAP_INT " ^ string_of_int i
+  | HEAP_BOOL true -> "HEAP_BOOL true"
   | HEAP_BOOL false -> "HEAP_BOOL false"
-  | HEAP_UNIT       -> "HEAP_UNIT"
-  | HEAP_HI i       -> "HEAP_HI " ^ (string_of_int i)
-  | HEAP_CI i       -> "HEAP_CI " ^ (string_of_int i)
-  | HEAP_HEADER (i, t) -> "HEAP_HEADER(" ^ (string_of_int i) ^ ", " ^ (string_of_heap_type t) ^ ")"
-
+  | HEAP_UNIT -> "HEAP_UNIT"
+  | HEAP_HI i -> "HEAP_HI " ^ string_of_int i
+  | HEAP_CI i -> "HEAP_CI " ^ string_of_int i
+  | HEAP_HEADER (i, t) ->
+      "HEAP_HEADER(" ^ string_of_int i ^ ", " ^ string_of_heap_type t ^ ")"
 
 let string_of_value_path = function
-  | STACK_LOCATION offset -> "STACK_LOCATION " ^ (string_of_int offset)
-  | HEAP_LOCATION offset  -> "HEAP_LOCATION " ^ (string_of_int offset)
+  | STACK_LOCATION offset -> "STACK_LOCATION " ^ string_of_int offset
+  | HEAP_LOCATION offset -> "HEAP_LOCATION " ^ string_of_int offset
 
 let string_of_location = function
-  | (l, None) -> l
-  | (l, Some i) -> l ^ " = " ^ (string_of_int i)
+  | l, None -> l
+  | l, Some i -> l ^ " = " ^ string_of_int i
 
 let string_of_instruction = function
- | UNARY op            -> "UNARY " ^ string_of_uop op
- | OPER op             -> "OPER " ^ string_of_bop op
- | MK_PAIR             -> "MK_PAIR"
- | FST                 -> "FST"
- | SND                 -> "SND"
- | MK_INL              -> "MK_INL"
- | MK_INR              -> "MK_INR"
- | MK_REF              -> "MK_REF"
- | PUSH v              -> "PUSH " ^ string_of_stack_item v
- | LOOKUP p            -> "LOOKUP " ^ string_of_value_path p
- | TEST l              -> "TEST " ^ string_of_location l
- | CASE l              -> "CASE " ^ string_of_location l
- | GOTO l              -> "GOTO " ^ string_of_location l
- | APPLY               -> "APPLY"
- | RETURN              -> "RETURN"
- | HALT                -> "HALT"
- | LABEL l             -> "LABEL " ^ l
- | SWAP                -> "SWAP"
- | POP                 -> "POP"
- | DEREF               -> "DEREF"
- | ASSIGN              -> "ASSIGN"
- | MK_CLOSURE (loc, n)
-                       -> "MK_CLOSURE(" ^ string_of_location loc
-	                      ^ ", " ^ string_of_int n ^ ")"
+  | UNARY op -> "UNARY " ^ string_of_uop op
+  | OPER op -> "OPER " ^ string_of_bop op
+  | MK_PAIR -> "MK_PAIR"
+  | FST -> "FST"
+  | SND -> "SND"
+  | MK_INL -> "MK_INL"
+  | MK_INR -> "MK_INR"
+  | MK_REF -> "MK_REF"
+  | PUSH v -> "PUSH " ^ string_of_stack_item v
+  | LOOKUP p -> "LOOKUP " ^ string_of_value_path p
+  | TEST l -> "TEST " ^ string_of_location l
+  | CASE l -> "CASE " ^ string_of_location l
+  | GOTO l -> "GOTO " ^ string_of_location l
+  | APPLY -> "APPLY"
+  | RETURN -> "RETURN"
+  | HALT -> "HALT"
+  | LABEL l -> "LABEL " ^ l
+  | SWAP -> "SWAP"
+  | POP -> "POP"
+  | DEREF -> "DEREF"
+  | ASSIGN -> "ASSIGN"
+  | MK_CLOSURE (loc, n) ->
+      "MK_CLOSURE(" ^ string_of_location loc ^ ", " ^ string_of_int n ^ ")"
+
 let rec string_of_listing = function
   | [] -> "\n"
   | LABEL l :: rest -> "\n" ^ l ^ " :" ^ string_of_listing rest
   | i :: rest -> "\n\t" ^ string_of_instruction i ^ string_of_listing rest
 
-let string_of_installed_code (code, size)  =
-    let rec aux k =
-      if size = k
-      then ""
-      else string_of_int k ^ ": "
-           ^ string_of_instruction code.(k)
-           ^ "\n" ^ aux (k+1)
-    in aux 0
+let string_of_installed_code (code, size) =
+  let rec aux k =
+    if size = k then
+      ""
+    else
+      string_of_int k ^ ": "
+      ^ string_of_instruction code.(k)
+      ^ "\n"
+      ^ aux (k + 1)
+  in
+  aux 0
 
-let string_of_stack(sp, stack) =
-    let rec aux carry j =
-      if j = sp then carry
-      else aux (string_of_int j ^ ": "
-                ^ string_of_stack_item (Array.get stack j)
-                ^ "\n" ^ carry) (j + 1)
-    in aux "" 0
+let string_of_stack (sp, stack) =
+  let rec aux carry j =
+    if j = sp then
+      carry
+    else
+      aux
+        (string_of_int j ^ ": "
+        ^ string_of_stack_item (Array.get stack j)
+        ^ "\n" ^ carry)
+        (j + 1)
+  in
+  aux "" 0
 
 let string_of_heap vm =
-    let rec aux k =
-      if vm.hp <= k
-      then ""
-      else string_of_int k ^ " -> " ^ string_of_heap_item (vm.heap.(k)) ^ "\n" ^ aux (k+1)
-    in "\nHeap = \n" ^ aux 0
-
+  let rec aux k =
+    if vm.hp <= k then
+      ""
+    else
+      string_of_int k ^ " -> "
+      ^ string_of_heap_item vm.heap.(k)
+      ^ "\n"
+      ^ aux (k + 1)
+  in
+  "\nHeap = \n" ^ aux 0
 
 let string_of_state vm =
   "cp = " ^ string_of_int vm.cp ^ " -> "
-  ^ string_of_instruction (get_instruction vm) ^ "\n"
-  ^ "fp = " ^ string_of_int vm.fp ^ "\n"
-  ^ "Stack = \n" ^ string_of_stack(vm.sp, vm.stack)
-  ^ if vm.hp = 0 then "" else string_of_heap vm
-
+  ^ string_of_instruction (get_instruction vm)
+  ^ "\n" ^ "fp = " ^ string_of_int vm.fp ^ "\n" ^ "Stack = \n"
+  ^ string_of_stack (vm.sp, vm.stack)
+  ^
+  if vm.hp = 0 then
+    ""
+  else
+    string_of_heap vm
 
 (* the following two functions are needed to
    pretty-print heap and stack values
 *)
 let rec string_of_heap_value a vm =
-    match Array.get vm.heap a with
-  | HEAP_INT i      -> string_of_int i
-  | HEAP_BOOL true  -> "true"
+  match Array.get vm.heap a with
+  | HEAP_INT i -> string_of_int i
+  | HEAP_BOOL true -> "true"
   | HEAP_BOOL false -> "false"
-  | HEAP_UNIT       -> "()"
-  | HEAP_HI i       -> string_of_heap_value i vm
-  | HEAP_CI _       -> Errors.complain "string_of_heap_value: expecting value in heap, found code index"
-  | HEAP_HEADER (_, ht) ->
-    (match ht with
-    | HT_PAIR -> "(" ^ (string_of_heap_value (a + 1) vm) ^ ", " ^ (string_of_heap_value (a + 2) vm) ^ ")"
-    | HT_INL -> "inl(" ^ (string_of_heap_value (a + 1) vm) ^ ")"
-    | HT_INR -> "inr(" ^ (string_of_heap_value (a + 1) vm) ^ ")"
-    | HT_CLOSURE -> "CLOSURE"
-    )
+  | HEAP_UNIT -> "()"
+  | HEAP_HI i -> string_of_heap_value i vm
+  | HEAP_CI _ ->
+      Errors.complain
+        "string_of_heap_value: expecting value in heap, found code index"
+  | HEAP_HEADER (_, ht) -> (
+      match ht with
+      | HT_PAIR ->
+          "("
+          ^ string_of_heap_value (a + 1) vm
+          ^ ", "
+          ^ string_of_heap_value (a + 2) vm
+          ^ ")"
+      | HT_INL -> "inl(" ^ string_of_heap_value (a + 1) vm ^ ")"
+      | HT_INR -> "inr(" ^ string_of_heap_value (a + 1) vm ^ ")"
+      | HT_CLOSURE -> "CLOSURE")
 
 let string_of_value vm =
-    match stack_top vm with
-  | STACK_INT i      -> string_of_int i
-  | STACK_BOOL true  -> "true"
+  match stack_top vm with
+  | STACK_INT i -> string_of_int i
+  | STACK_BOOL true -> "true"
   | STACK_BOOL false -> "false"
-  | STACK_UNIT       -> "()"
-  | STACK_HI a       -> string_of_heap_value a vm
-  | STACK_RA _       -> Errors.complain "string_of_value: expecting value on stack top, found code index"
-  | STACK_FP _       -> Errors.complain "string_of_value: expecting value on stack top, found frame pointer"
-
-
+  | STACK_UNIT -> "()"
+  | STACK_HI a -> string_of_heap_value a vm
+  | STACK_RA _ ->
+      Errors.complain
+        "string_of_value: expecting value on stack top, found code index"
+  | STACK_FP _ ->
+      Errors.complain
+        "string_of_value: expecting value on stack top, found frame pointer"
 
 (***************************** THE MACHINE ********************************)
 
-
-let readint () = let _ = print_string "input> " in read_int()
+let readint () =
+  let _ = print_string "input> " in
+  read_int ()
 
 let stack_to_heap_item = function
   | STACK_INT i -> HEAP_INT i
@@ -248,7 +259,8 @@ let stack_to_heap_item = function
   | STACK_UNIT -> HEAP_UNIT
   | STACK_HI i -> HEAP_HI i
   | STACK_RA i -> HEAP_CI i
-  | STACK_FP _ -> Errors.complain "stack_to_heap_item: no frame pointer allowed on heap"
+  | STACK_FP _ ->
+      Errors.complain "stack_to_heap_item: no frame pointer allowed on heap"
 
 let heap_to_stack_item = function
   | HEAP_INT i -> STACK_INT i
@@ -256,61 +268,72 @@ let heap_to_stack_item = function
   | HEAP_UNIT -> STACK_UNIT
   | HEAP_HI i -> STACK_HI i
   | HEAP_CI i -> STACK_RA i
-  | HEAP_HEADER (_,_) -> Errors.complain "heap_to_stack_item : heap header not allowed on stack"
+  | HEAP_HEADER (_, _) ->
+      Errors.complain "heap_to_stack_item : heap header not allowed on stack"
 
 (* cp := cp + 1  *)
 let advance_cp vm =
-    if vm.cp < vm.code_bound
-    then { vm with cp = vm.cp + 1 }
-    else { vm with status = CodeIndexOutOfBound }
+  if vm.cp < vm.code_bound then
+    { vm with cp = vm.cp + 1 }
+  else
+    { vm with status = CodeIndexOutOfBound }
 
-let goto(i, vm) = { vm with cp = i }
+let goto (i, vm) = { vm with cp = i }
 
 (* pop n items from stack *)
-let pop(n, vm) =
-    if 0 <= vm.sp - n
-    then { vm with sp =vm.sp - n  }
-    else { vm with status = StackUnderflow }
+let pop (n, vm) =
+  if 0 <= vm.sp - n then
+    { vm with sp = vm.sp - n }
+  else
+    { vm with status = StackUnderflow }
 
-let pop_top vm = let c = stack_top vm in (c, pop(1, vm))
+let pop_top vm =
+  let c = stack_top vm in
+  (c, pop (1, vm))
 
 (* pop c onto stack  *)
-let push(c, vm) =
-    if vm.sp < vm.stack_bound
-    then let _ = Array.set vm.stack vm.sp c in { vm with sp = vm.sp + 1 }
-    else { vm with status = StackIndexOutOfBound }
+let push (c, vm) =
+  if vm.sp < vm.stack_bound then
+    let _ = Array.set vm.stack vm.sp c in
+    { vm with sp = vm.sp + 1 }
+  else
+    { vm with status = StackIndexOutOfBound }
 
 let swap vm =
-    let (c1, vm1) = pop_top vm in
-    let (c2, vm2) = pop_top vm1 in push(c2, push(c1, vm2))
-
+  let c1, vm1 = pop_top vm in
+  let c2, vm2 = pop_top vm1 in
+  push (c2, push (c1, vm2))
 
 let do_unary = function
-  | (NOT,  STACK_BOOL m) -> STACK_BOOL (not m)
-  | (NEG,  STACK_INT m)  -> STACK_INT (-m)
-  | (READ, STACK_UNIT)   -> STACK_INT (readint())
-  | (op, _) -> Errors.complain ("do_unary: malformed unary operator: " ^ (string_of_unary_oper op))
+  | NOT, STACK_BOOL m -> STACK_BOOL (not m)
+  | NEG, STACK_INT m -> STACK_INT (-m)
+  | READ, STACK_UNIT -> STACK_INT (readint ())
+  | op, _ ->
+      Errors.complain
+        ("do_unary: malformed unary operator: " ^ string_of_unary_oper op)
 
 let do_oper = function
-  | (AND,  STACK_BOOL m,  STACK_BOOL n) -> STACK_BOOL (m && n)
-  | (OR,   STACK_BOOL m,  STACK_BOOL n) -> STACK_BOOL (m || n)
-  | (EQB,  STACK_BOOL m,  STACK_BOOL n) -> STACK_BOOL (m = n)
-  | (LT,   STACK_INT m,   STACK_INT n)  -> STACK_BOOL (m < n)
-  | (EQI,  STACK_INT m,   STACK_INT n)  -> STACK_BOOL (m = n)
-  | (ADD,  STACK_INT m,   STACK_INT n)  -> STACK_INT (m + n)
-  | (SUB,  STACK_INT m,   STACK_INT n)  -> STACK_INT (m - n)
-  | (MUL,  STACK_INT m,   STACK_INT n)  -> STACK_INT (m * n)
-  | (DIV,  STACK_INT m,   STACK_INT n)  -> STACK_INT (m / n)
-  | (op, _, _)  -> Errors.complain ("do_oper: malformed binary operator: " ^ (string_of_oper op))
+  | AND, STACK_BOOL m, STACK_BOOL n -> STACK_BOOL (m && n)
+  | OR, STACK_BOOL m, STACK_BOOL n -> STACK_BOOL (m || n)
+  | EQB, STACK_BOOL m, STACK_BOOL n -> STACK_BOOL (m = n)
+  | LT, STACK_INT m, STACK_INT n -> STACK_BOOL (m < n)
+  | EQI, STACK_INT m, STACK_INT n -> STACK_BOOL (m = n)
+  | ADD, STACK_INT m, STACK_INT n -> STACK_INT (m + n)
+  | SUB, STACK_INT m, STACK_INT n -> STACK_INT (m - n)
+  | MUL, STACK_INT m, STACK_INT n -> STACK_INT (m * n)
+  | DIV, STACK_INT m, STACK_INT n -> STACK_INT (m / n)
+  | op, _, _ ->
+      Errors.complain
+        ("do_oper: malformed binary operator: " ^ string_of_oper op)
 
+let perform_op (op, vm) =
+  let v_right, vm1 = pop_top vm in
+  let v_left, vm2 = pop_top vm1 in
+  push (do_oper (op, v_left, v_right), vm2)
 
-let perform_op(op, vm) =
-    let (v_right, vm1) = pop_top vm in
-    let (v_left, vm2) = pop_top vm1 in
-      push(do_oper(op, v_left, v_right), vm2)
-
-let perform_unary(op, vm) =
-    let (v, vm1) = pop_top vm in push(do_unary(op, v), vm1)
+let perform_unary (op, vm) =
+  let v, vm1 = pop_top vm in
+  push (do_unary (op, v), vm1)
 
 (* implement garbage collection!
 
@@ -323,229 +346,254 @@ let perform_unary(op, vm) =
    None = no progress
    Some(vm') = progress made, resulting in vm'
 *)
-let invoke_garbage_collection _  = None
+let invoke_garbage_collection _ = None
 
-let allocate(n, vm) =
-    let hp1 = vm.hp in
-    if hp1 + n < vm.heap_bound
-    then (hp1, { vm with hp = vm.hp + n })
-    else match invoke_garbage_collection vm with
-        | None -> Errors.complain "allocate : heap exhausted"
-        | Some vm2 ->
-          if vm2.hp + n < vm2.heap_bound
-          then (vm2.hp, { vm2 with hp = vm2.hp + n })
-          else Errors.complain "allocate : heap exhausted"
+let allocate (n, vm) =
+  let hp1 = vm.hp in
+  if hp1 + n < vm.heap_bound then
+    (hp1, { vm with hp = vm.hp + n })
+  else
+    match
+      invoke_garbage_collection vm
+    with
+    | None -> Errors.complain "allocate : heap exhausted"
+    | Some vm2 ->
+        if vm2.hp + n < vm2.heap_bound then
+          (vm2.hp, { vm2 with hp = vm2.hp + n })
+        else
+          Errors.complain "allocate : heap exhausted"
 
 let mk_pair vm =
-    let (v_right, vm1) = pop_top vm in
-    let (v_left, vm2) = pop_top vm1 in
-    let (a, vm3) = allocate(3, vm2) in
-    let header = HEAP_HEADER (3, HT_PAIR) in
-    let _ = Array.set vm.heap a header in
-    let _ = Array.set vm.heap (a + 1) (stack_to_heap_item v_left) in
-    let _ = Array.set vm.heap (a + 2) (stack_to_heap_item v_right) in
-        push(STACK_HI a, vm3)
+  let v_right, vm1 = pop_top vm in
+  let v_left, vm2 = pop_top vm1 in
+  let a, vm3 = allocate (3, vm2) in
+  let header = HEAP_HEADER (3, HT_PAIR) in
+  let _ = Array.set vm.heap a header in
+  let _ = Array.set vm.heap (a + 1) (stack_to_heap_item v_left) in
+  let _ = Array.set vm.heap (a + 2) (stack_to_heap_item v_right) in
+  push (STACK_HI a, vm3)
 
 let do_fst vm =
-    let (v, vm1) = pop_top vm in
-    match v with
-    | STACK_HI a ->
-      (match vm1.heap.(a) with
-      | HEAP_HEADER(_, HT_PAIR) ->
-           push(heap_to_stack_item (vm.heap.(a + 1)), vm1)
-      | _ -> Errors.complain "do_fst : unexpectd heap item"
-      )
-    | _ -> Errors.complain "do_fst : expecting heap pointer on stack"
-
+  let v, vm1 = pop_top vm in
+  match v with
+  | STACK_HI a -> (
+      match vm1.heap.(a) with
+      | HEAP_HEADER (_, HT_PAIR) ->
+          push (heap_to_stack_item vm.heap.(a + 1), vm1)
+      | _ -> Errors.complain "do_fst : unexpectd heap item")
+  | _ -> Errors.complain "do_fst : expecting heap pointer on stack"
 
 let do_snd vm =
-    let (v, vm1) = pop_top vm in
-    match v with
-    | STACK_HI a ->
-      (match vm1.heap.(a) with
-      | HEAP_HEADER(_, HT_PAIR) ->
-           push(heap_to_stack_item (vm.heap.(a + 2)), vm1)
-      | _ -> Errors.complain "do_snd : unexpectd heap item"
-      )
-    | _ -> Errors.complain "do_snd : expecting heap pointer on stack"
+  let v, vm1 = pop_top vm in
+  match v with
+  | STACK_HI a -> (
+      match vm1.heap.(a) with
+      | HEAP_HEADER (_, HT_PAIR) ->
+          push (heap_to_stack_item vm.heap.(a + 2), vm1)
+      | _ -> Errors.complain "do_snd : unexpectd heap item")
+  | _ -> Errors.complain "do_snd : expecting heap pointer on stack"
 
 let mk_inl vm =
-    let (v, vm1) = pop_top vm in
-    let (a, vm2) = allocate(2, vm1) in
-    let header = HEAP_HEADER (2, HT_INL) in
-    let _ = Array.set vm2.heap a header in
-    let _ = Array.set vm2.heap (a + 1) (stack_to_heap_item v) in
-        push(STACK_HI a, vm2)
+  let v, vm1 = pop_top vm in
+  let a, vm2 = allocate (2, vm1) in
+  let header = HEAP_HEADER (2, HT_INL) in
+  let _ = Array.set vm2.heap a header in
+  let _ = Array.set vm2.heap (a + 1) (stack_to_heap_item v) in
+  push (STACK_HI a, vm2)
 
 let mk_inr vm =
-    let (v, vm1) = pop_top vm in
-    let (a, vm2) = allocate(2, vm1) in
-    let header = HEAP_HEADER (2, HT_INR) in
-    let _ = Array.set vm2.heap a header in
-    let _ = Array.set vm2.heap (a + 1) (stack_to_heap_item v) in
-        push(STACK_HI a, vm2)
+  let v, vm1 = pop_top vm in
+  let a, vm2 = allocate (2, vm1) in
+  let header = HEAP_HEADER (2, HT_INR) in
+  let _ = Array.set vm2.heap a header in
+  let _ = Array.set vm2.heap (a + 1) (stack_to_heap_item v) in
+  push (STACK_HI a, vm2)
 
-let case(i, vm) =
-    let (c, vm1) = pop_top vm in
-    match c with
-    | STACK_HI a ->
-	let vm2 = push(heap_to_stack_item(vm.heap.(a + 1)), vm1) in
-         (match vm1.heap.(a) with
-	 | HEAP_HEADER(_, HT_INR) -> goto(i, vm2)
-	 | HEAP_HEADER(_, HT_INL) -> advance_cp vm2
-         | _ -> Errors.complain "case: runtime error, expecting union header in heap"
-         )
-    | _ -> Errors.complain "case: runtime error, expecting heap index on top of stack"
-
+let case (i, vm) =
+  let c, vm1 = pop_top vm in
+  match c with
+  | STACK_HI a -> (
+      let vm2 = push (heap_to_stack_item vm.heap.(a + 1), vm1) in
+      match vm1.heap.(a) with
+      | HEAP_HEADER (_, HT_INR) -> goto (i, vm2)
+      | HEAP_HEADER (_, HT_INL) -> advance_cp vm2
+      | _ ->
+          Errors.complain "case: runtime error, expecting union header in heap")
+  | _ ->
+      Errors.complain
+        "case: runtime error, expecting heap index on top of stack"
 
 let mk_ref vm =
-    let (v, vm1) = pop_top vm in
-    let (a, vm2) = allocate(1, vm1) in
-    let _ = Array.set vm2.heap a (stack_to_heap_item v) in push(STACK_HI a, vm2)
-
+  let v, vm1 = pop_top vm in
+  let a, vm2 = allocate (1, vm1) in
+  let _ = Array.set vm2.heap a (stack_to_heap_item v) in
+  push (STACK_HI a, vm2)
 
 let deref vm =
-    let (v, vm1) = pop_top vm in
-    match v with
-    | STACK_HI a -> push(heap_to_stack_item (Array.get vm1.heap a) , vm1)
-    | _ -> Errors.complain "deref"
+  let v, vm1 = pop_top vm in
+  match v with
+  | STACK_HI a -> push (heap_to_stack_item (Array.get vm1.heap a), vm1)
+  | _ -> Errors.complain "deref"
 
 let assign vm =
-    let (c1, vm1) = pop_top vm in
-    let (c2, _) = pop_top vm1 in
-    match c2 with
-    | STACK_HI a ->
-        if vm.sp < vm.heap_bound
-        then let _ = Array.set vm.heap a (stack_to_heap_item c1) in push(STACK_UNIT, vm)
-        else { vm with status = HeapIndexOutOfBound }
-    | _ -> Errors.complain "assing: runtime error, expecting heap index on stack"
+  let c1, vm1 = pop_top vm in
+  let c2, _ = pop_top vm1 in
+  match c2 with
+  | STACK_HI a ->
+      if vm.sp < vm.heap_bound then
+        let _ = Array.set vm.heap a (stack_to_heap_item c1) in
+        push (STACK_UNIT, vm)
+      else
+        { vm with status = HeapIndexOutOfBound }
+  | _ -> Errors.complain "assing: runtime error, expecting heap index on stack"
 
-
-let test(i, vm) =
-    pop(1, if stack_top vm = STACK_BOOL true then advance_cp vm else { vm with cp = i })
+let test (i, vm) =
+  pop
+    ( 1,
+      if stack_top vm = STACK_BOOL true then
+        advance_cp vm
+      else
+        { vm with cp = i } )
 
 let return vm =
-    let current_fp = vm.fp in
-    match vm.stack.(current_fp), vm.stack.(vm.fp + 1) with
-    | (STACK_FP saved_fp, STACK_RA k) ->
-       let return_value = stack_top vm
-       in push(return_value, { vm with cp = k; fp = saved_fp ; sp = current_fp - 2})
-    | _ -> Errors.complain "return : malformed stack frame"
+  let current_fp = vm.fp in
+  match (vm.stack.(current_fp), vm.stack.(vm.fp + 1)) with
+  | STACK_FP saved_fp, STACK_RA k ->
+      let return_value = stack_top vm in
+      push (return_value, { vm with cp = k; fp = saved_fp; sp = current_fp - 2 })
+  | _ -> Errors.complain "return : malformed stack frame"
 
 let fetch fp vm = function
   | STACK_LOCATION offset -> vm.stack.(fp + offset)
-  | HEAP_LOCATION offset ->
-    (match vm.stack.(fp - 1) with
-    | STACK_HI a -> heap_to_stack_item (vm.heap.(a + offset + 1))
-    | _ -> Errors.complain "search : expecting closure pointer"
-    )
+  | HEAP_LOCATION offset -> (
+      match vm.stack.(fp - 1) with
+      | STACK_HI a -> heap_to_stack_item vm.heap.(a + offset + 1)
+      | _ -> Errors.complain "search : expecting closure pointer")
 
-let lookup fp vm vlp = push(fetch fp vm vlp, vm)
+let lookup fp vm vlp = push (fetch fp vm vlp, vm)
 
 let mk_closure = function
-  | ((_, Some i), n, vm) ->
-    let (a, vm1) = allocate(2 + n, vm)       in
-    let header = HEAP_HEADER (2 + n, HT_CLOSURE) in
-    let code_address = HEAP_CI i             in
-    let _ = vm1.heap.(a)     <- header       in
-    let _ = vm1.heap.(a + 1) <- code_address in
-    let rec aux m =
-        if m = n
-        then ()
-        else let v = stack_to_heap_item vm1.stack.(vm.sp - (m + 1)) in
-             let _ = vm1.heap.(a + m + 2) <- v in
-                aux (m + 1)
-    in
-    let _ = aux 0 in
-    let vm2 = pop(n, vm1) in push(STACK_HI a, vm2)
-  | ((_, None), _, _) ->  Errors.complain "mk_closure : internal error, no address in closure!"
+  | (_, Some i), n, vm ->
+      let a, vm1 = allocate (2 + n, vm) in
+      let header = HEAP_HEADER (2 + n, HT_CLOSURE) in
+      let code_address = HEAP_CI i in
+      let _ = vm1.heap.(a) <- header in
+      let _ = vm1.heap.(a + 1) <- code_address in
+      let rec aux m =
+        if m = n then
+          ()
+        else
+          let v = stack_to_heap_item vm1.stack.(vm.sp - (m + 1)) in
+          let _ = vm1.heap.(a + m + 2) <- v in
+          aux (m + 1)
+      in
+      let _ = aux 0 in
+      let vm2 = pop (n, vm1) in
+      push (STACK_HI a, vm2)
+  | (_, None), _, _ ->
+      Errors.complain "mk_closure : internal error, no address in closure!"
 
 let apply vm =
-    match stack_top vm with
-    | STACK_HI a ->
-        (match vm.heap.(a+1) with
-        | HEAP_CI i ->
-          let new_fp = vm.sp
-          in let saved_fp = STACK_FP vm.fp
-          in let return_index = STACK_RA (vm.cp + 1)
-          in let new_vm = { vm with cp = i; fp = new_fp }
-          in push(return_index, push(saved_fp, new_vm ))
-        | _ -> Errors.complain "apply: runtime error, expecting code index in heap")
-    | _ -> Errors.complain "apply: runtime error, expecting heap index on top of stack"
-
+  match stack_top vm with
+  | STACK_HI a -> (
+      match vm.heap.(a + 1) with
+      | HEAP_CI i ->
+          let new_fp = vm.sp in
+          let saved_fp = STACK_FP vm.fp in
+          let return_index = STACK_RA (vm.cp + 1) in
+          let new_vm = { vm with cp = i; fp = new_fp } in
+          push (return_index, push (saved_fp, new_vm))
+      | _ ->
+          Errors.complain "apply: runtime error, expecting code index in heap")
+  | _ ->
+      Errors.complain
+        "apply: runtime error, expecting heap index on top of stack"
 
 let step vm =
- match get_instruction vm with
-  | UNARY op           -> advance_cp (perform_unary(op, vm))
-  | OPER op            -> advance_cp (perform_op(op, vm))
-  | MK_PAIR            -> advance_cp (mk_pair vm)
-  | FST                -> advance_cp (do_fst vm)
-  | SND                -> advance_cp (do_snd vm)
-  | MK_INL             -> advance_cp (mk_inl vm)
-  | MK_INR             -> advance_cp (mk_inr vm)
-  | PUSH c             -> advance_cp (push(c, vm))
-
-  | APPLY              -> apply vm
-  | LOOKUP vp          -> advance_cp (lookup vm.fp vm vp)
-  | RETURN             -> return vm
-  | MK_CLOSURE (l, n)  -> advance_cp (mk_closure(l, n, vm))
-
-  | SWAP               -> advance_cp (swap vm)
-  | POP                -> advance_cp (pop (1, vm))
-  | LABEL _            -> advance_cp vm
-  | DEREF              -> advance_cp (deref vm)
-  | MK_REF             -> advance_cp (mk_ref vm)
-  | ASSIGN             -> advance_cp(assign vm)
-  | HALT               -> { vm with status = Halted }
-  | GOTO ((_, Some i)) -> goto(i, vm)
-  | TEST ((_, Some i)) -> test(i, vm)
-  | CASE ((_, Some i)) -> case(i, vm)
-
-  | _ -> Errors.complain ("step : bad state = " ^ (string_of_state vm) ^ "\n")
-
+  match get_instruction vm with
+  | UNARY op -> advance_cp (perform_unary (op, vm))
+  | OPER op -> advance_cp (perform_op (op, vm))
+  | MK_PAIR -> advance_cp (mk_pair vm)
+  | FST -> advance_cp (do_fst vm)
+  | SND -> advance_cp (do_snd vm)
+  | MK_INL -> advance_cp (mk_inl vm)
+  | MK_INR -> advance_cp (mk_inr vm)
+  | PUSH c -> advance_cp (push (c, vm))
+  | APPLY -> apply vm
+  | LOOKUP vp -> advance_cp (lookup vm.fp vm vp)
+  | RETURN -> return vm
+  | MK_CLOSURE (l, n) -> advance_cp (mk_closure (l, n, vm))
+  | SWAP -> advance_cp (swap vm)
+  | POP -> advance_cp (pop (1, vm))
+  | LABEL _ -> advance_cp vm
+  | DEREF -> advance_cp (deref vm)
+  | MK_REF -> advance_cp (mk_ref vm)
+  | ASSIGN -> advance_cp (assign vm)
+  | HALT -> { vm with status = Halted }
+  | GOTO (_, Some i) -> goto (i, vm)
+  | TEST (_, Some i) -> test (i, vm)
+  | CASE (_, Some i) -> case (i, vm)
+  | _ -> Errors.complain ("step : bad state = " ^ string_of_state vm ^ "\n")
 
 (* DRIVER *)
 
 let rec driver n vm =
-    let _ = if Option.verbose
-            then print_string ("========== state " ^ (string_of_int n) ^
-                               " ==========\n" ^ (string_of_state vm) ^ "\n")
-            else ()
-    in if vm.status = Running then driver (n+1) (step vm) else vm
+  let _ =
+    if Option.verbose then
+      print_string
+        ("========== state " ^ string_of_int n ^ " ==========\n"
+       ^ string_of_state vm ^ "\n")
+    else
+      ()
+  in
+  if vm.status = Running then
+    driver (n + 1) (step vm)
+  else
+    vm
 
 let map_instruction_labels f = function
-     | GOTO (lab, _) -> GOTO (lab, Some(f lab))
-     | TEST (lab, _) -> TEST (lab, Some(f lab))
-     | CASE (lab, _) -> CASE (lab, Some(f lab))
-     | MK_CLOSURE (((lab, _)), n) -> MK_CLOSURE ((lab, Some(f lab)), n)
-     | inst -> inst
+  | GOTO (lab, _) -> GOTO (lab, Some (f lab))
+  | TEST (lab, _) -> TEST (lab, Some (f lab))
+  | CASE (lab, _) -> CASE (lab, Some (f lab))
+  | MK_CLOSURE ((lab, _), n) -> MK_CLOSURE ((lab, Some (f lab)), n)
+  | inst -> inst
 
 let rec find l y =
   match l with
   | [] -> Errors.complain ("Compile.find : " ^ y ^ " is not found")
-  | (x, v) :: rest -> if x = y then v else find rest y
-
+  | (x, v) :: rest ->
+      if x = y then
+        v
+      else
+        find rest y
 
 (* put code listing into an array, associate an array index to each label *)
 let load instr_list =
-   (* find array index for each label *)
-   let mk_label_to_address l =
-       let rec aux carry k = function
-         | [] -> carry
-         | ((LABEL lab) :: rest) -> aux ((lab, k) :: carry) (k +1) rest
-         | _ :: rest           -> aux carry (k+1) rest
-       in aux [] 0 l
-    in let label_to_address = mk_label_to_address instr_list
-    in let locate_instr = map_instruction_labels (find label_to_address)
-    in let located_instr_list = List.map locate_instr instr_list
-    in let result = Array.of_list located_instr_list
-    in (result, Array.length result)
+  (* find array index for each label *)
+  let mk_label_to_address l =
+    let rec aux carry k = function
+      | [] -> carry
+      | LABEL lab :: rest -> aux ((lab, k) :: carry) (k + 1) rest
+      | _ :: rest -> aux carry (k + 1) rest
+    in
+    aux [] 0 l
+  in
+  let label_to_address = mk_label_to_address instr_list in
+  let locate_instr = map_instruction_labels (find label_to_address) in
+  let located_instr_list = List.map locate_instr instr_list in
+  let result = Array.of_list located_instr_list in
+  (result, Array.length result)
 
 let initial_state l =
-  let (code_array, c_bound) = load l in
-  let _ = if Option.verbose
-          then print_string ("\nInstalled Code = \n" ^ (string_of_installed_code(code_array, c_bound)))
-          else () in
+  let code_array, c_bound = load l in
+  let _ =
+    if Option.verbose then
+      print_string
+        ("\nInstalled Code = \n"
+        ^ string_of_installed_code (code_array, c_bound))
+    else
+      ()
+  in
   {
     stack_bound = Option.stack_max;
     heap_bound = Option.heap_max;
@@ -561,25 +609,28 @@ let initial_state l =
   }
 
 let first_frame vm =
-    let saved_fp = STACK_FP 0
-    in let return_index = STACK_RA 0
-    in push(return_index, push(saved_fp, vm))
+  let saved_fp = STACK_FP 0 in
+  let return_index = STACK_RA 0 in
+  push (return_index, push (saved_fp, vm))
 
 let run l =
-    let vm = driver 1 (first_frame (initial_state l)) in
-    match vm.status with
-    | Halted   -> vm
-    | status -> Errors.complain ("run : stopped wth status " ^ (string_of_status status))
-
-
-
+  let vm = driver 1 (first_frame (initial_state l)) in
+  match vm.status with
+  | Halted -> vm
+  | status ->
+      Errors.complain ("run : stopped wth status " ^ string_of_status status)
 
 (* COMPILE *)
 
 let label_ref = ref 0
+
 let new_label =
-    let get () = let v = !label_ref in (label_ref := (!label_ref) + 1; "L"^ (string_of_int v))
-    in get
+  let get () =
+    let v = !label_ref in
+    label_ref := !label_ref + 1;
+    "L" ^ string_of_int v
+  in
+  get
 
 (*
 
@@ -611,109 +662,132 @@ fp ->[old fp        ]
 *)
 
 let positions l =
-    let rec aux k = function
+  let rec aux k = function
     | [] -> []
-    | a :: rest -> (a, k) :: (aux (k+1) rest)
-    in aux 1 l
-
+    | a :: rest -> (a, k) :: aux (k + 1) rest
+  in
+  aux 1 l
 
 let rec comp vmap = function
-  | Unit           -> ([], [PUSH STACK_UNIT])
-  | Boolean b      -> ([], [PUSH (STACK_BOOL b)])
-  | Integer n      -> ([], [PUSH (STACK_INT n)])
-  | UnaryOp (op, e) -> let (defs, c) = comp vmap e in  (defs, c @ [UNARY op])
-  | Op (e1, op, e2) -> let (defs1, c1) = comp vmap e1 in
-                      let (defs2, c2) = comp vmap e2 in
-                          (defs1 @ defs2, c1 @ c2 @ [OPER op])
-  | Pair (e1, e2)   -> let (defs1, c1) = comp vmap e1 in
-                      let (defs2, c2) = comp vmap e2 in
-                          (defs1 @ defs2, c1 @ c2 @ [MK_PAIR])
-  | Fst e          -> let (defs, c) = comp vmap e in (defs, c @ [FST])
-  | Snd e          -> let (defs, c) = comp vmap e in (defs, c @ [SND])
-  | Inl e          -> let (defs, c) = comp vmap e in (defs, c @ [MK_INL])
-  | Inr e          -> let (defs, c) = comp vmap e in (defs, c @ [MK_INR])
+  | Unit -> ([], [ PUSH STACK_UNIT ])
+  | Boolean b -> ([], [ PUSH (STACK_BOOL b) ])
+  | Integer n -> ([], [ PUSH (STACK_INT n) ])
+  | UnaryOp (op, e) ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ UNARY op ])
+  | Op (e1, op, e2) ->
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap e2 in
+      (defs1 @ defs2, c1 @ c2 @ [ OPER op ])
+  | Pair (e1, e2) ->
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap e2 in
+      (defs1 @ defs2, c1 @ c2 @ [ MK_PAIR ])
+  | Fst e ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ FST ])
+  | Snd e ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ SND ])
+  | Inl e ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ MK_INL ])
+  | Inr e ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ MK_INR ])
   | Case (e1, (x1, e2), (x2, e3)) ->
-                      let inr_label = new_label () in
-                      let after_inr_label = new_label () in
-                      let (defs1, c1) = comp vmap e1 in
-                      let (defs2, c2) = comp vmap (Lambda (x1, e2)) in
-                      let (defs3, c3) = comp vmap (Lambda (x2, e3)) in
-                         (defs1 @ defs2 @ defs3,
-                          (c1
-   		           @ [CASE (inr_label, None)]
-                           @ c2
-		           @ [APPLY; GOTO (after_inr_label, None);
-                              LABEL inr_label]
-                           @ c3
-		           @ [APPLY; LABEL after_inr_label]))
-  | If (e1, e2, e3) -> let else_label = new_label () in
-                      let after_else_label = new_label () in
-                      let (defs1, c1) = comp vmap e1 in
-                      let (defs2, c2) = comp vmap e2 in
-                      let (defs3, c3) = comp vmap e3 in
-                         (defs1 @ defs2 @ defs3,
-                          (c1
-   		           @ [TEST (else_label, None)]
-                           @ c2
-		           @ [GOTO (after_else_label, None); LABEL else_label]
-                           @ c3
-		           @ [LABEL after_else_label]))
- | Seq []         -> ([], [])
- | Seq [e]        -> comp vmap e
- | Seq (e ::rest) -> let (defs1, c1) = comp vmap e in
-                     let (defs2, c2) = comp vmap (Seq rest) in
-                       (defs1 @ defs2, c1 @ [POP] @ c2)
- | Ref e          -> let (defs, c) = comp vmap e in (defs, c @ [MK_REF])
- | Deref e        -> let (defs, c) = comp vmap e in (defs, c @ [DEREF])
- | While (e1, e2)  -> let test_label = new_label () in
-                      let end_label = new_label () in
-                      let (defs1, c1) = comp vmap e1 in
-                      let (defs2, c2) = comp vmap e2 in
-                         (defs1 @ defs2,
-                          [LABEL test_label]
-                           @ c1
-                           @ [TEST (end_label, None)]
-                           @ c2
-                           @ [POP; GOTO (test_label, None); LABEL (end_label); PUSH (STACK_UNIT)])
- | Assign (e1, e2) -> let (defs1, c1) = comp vmap e1 in
-                     let (defs2, c2) = comp vmap e2 in
-                         (defs1 @ defs2, c1 @ c2 @ [ASSIGN])
-
- | App (e1, e2)    -> let (defs1, c1) = comp vmap e1 in
-                     let (defs2, c2) = comp vmap e2 in
-                          (defs1 @ defs2, c2 @ c1 @ [APPLY])
- | Var x           -> ([], [LOOKUP (find vmap x)])
- | LetFun (f, (x, e1), e2) -> comp vmap (App (Lambda(f, e2), Lambda( x, e1)))
- | Lambda (x, e)           -> comp_lambda vmap (None, x, e)
- | LetRecFun (f, (x, e1), e2) ->
-                      let (defs1, c1) = comp vmap (Lambda(f, e2)) in
-                      let (defs2, c2) = comp_lambda vmap (Some f, x, e1) in
-                          (defs1 @ defs2, c2 @ c1 @ [APPLY])
+      let inr_label = new_label () in
+      let after_inr_label = new_label () in
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap (Lambda (x1, e2)) in
+      let defs3, c3 = comp vmap (Lambda (x2, e3)) in
+      ( defs1 @ defs2 @ defs3,
+        c1
+        @ [ CASE (inr_label, None) ]
+        @ c2
+        @ [ APPLY; GOTO (after_inr_label, None); LABEL inr_label ]
+        @ c3
+        @ [ APPLY; LABEL after_inr_label ] )
+  | If (e1, e2, e3) ->
+      let else_label = new_label () in
+      let after_else_label = new_label () in
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap e2 in
+      let defs3, c3 = comp vmap e3 in
+      ( defs1 @ defs2 @ defs3,
+        c1
+        @ [ TEST (else_label, None) ]
+        @ c2
+        @ [ GOTO (after_else_label, None); LABEL else_label ]
+        @ c3 @ [ LABEL after_else_label ] )
+  | Seq [] -> ([], [])
+  | Seq [ e ] -> comp vmap e
+  | Seq (e :: rest) ->
+      let defs1, c1 = comp vmap e in
+      let defs2, c2 = comp vmap (Seq rest) in
+      (defs1 @ defs2, c1 @ [ POP ] @ c2)
+  | Ref e ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ MK_REF ])
+  | Deref e ->
+      let defs, c = comp vmap e in
+      (defs, c @ [ DEREF ])
+  | While (e1, e2) ->
+      let test_label = new_label () in
+      let end_label = new_label () in
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap e2 in
+      ( defs1 @ defs2,
+        [ LABEL test_label ] @ c1
+        @ [ TEST (end_label, None) ]
+        @ c2
+        @ [ POP; GOTO (test_label, None); LABEL end_label; PUSH STACK_UNIT ] )
+  | Assign (e1, e2) ->
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap e2 in
+      (defs1 @ defs2, c1 @ c2 @ [ ASSIGN ])
+  | App (e1, e2) ->
+      let defs1, c1 = comp vmap e1 in
+      let defs2, c2 = comp vmap e2 in
+      (defs1 @ defs2, c2 @ c1 @ [ APPLY ])
+  | Var x -> ([], [ LOOKUP (find vmap x) ])
+  | LetFun (f, (x, e1), e2) -> comp vmap (App (Lambda (f, e2), Lambda (x, e1)))
+  | Lambda (x, e) -> comp_lambda vmap (None, x, e)
+  | LetRecFun (f, (x, e1), e2) ->
+      let defs1, c1 = comp vmap (Lambda (f, e2)) in
+      let defs2, c2 = comp_lambda vmap (Some f, x, e1) in
+      (defs1 @ defs2, c2 @ c1 @ [ APPLY ])
 
 and comp_lambda vmap (f_opt, x, e) =
-    let bound_vars = match f_opt with | None -> [x]          | Some f -> [x; f] in
-    let f = new_label () in
-    let f_bind =     match f_opt with | None -> []           | Some f -> [(f, STACK_LOCATION (-1))]  in
-    let x_bind = (x, STACK_LOCATION (-2)) in
-    let fvars = Free_vars.free_vars (bound_vars, e)   in
-    let fetch_fvars = List.map (fun y -> LOOKUP (find vmap y)) fvars in
-    let fvar_bind (y, p) = (y, HEAP_LOCATION p) in
-    let env_bind = List.map fvar_bind (positions fvars) in
-    let new_vmap = x_bind :: (f_bind @ env_bind @ vmap) in
-    let (defs, c) = comp new_vmap e in
-    let def = [LABEL f] @ c @ [RETURN] in
-     (def @ defs, (List.rev fetch_fvars) @ [MK_CLOSURE ((f, None), List.length fvars)])
+  let bound_vars = match f_opt with None -> [ x ] | Some f -> [ x; f ] in
+  let f = new_label () in
+  let f_bind =
+    match f_opt with None -> [] | Some f -> [ (f, STACK_LOCATION (-1)) ]
+  in
+  let x_bind = (x, STACK_LOCATION (-2)) in
+  let fvars = Free_vars.free_vars (bound_vars, e) in
+  let fetch_fvars = List.map (fun y -> LOOKUP (find vmap y)) fvars in
+  let fvar_bind (y, p) = (y, HEAP_LOCATION p) in
+  let env_bind = List.map fvar_bind (positions fvars) in
+  let new_vmap = x_bind :: (f_bind @ env_bind @ vmap) in
+  let defs, c = comp new_vmap e in
+  let def = [ LABEL f ] @ c @ [ RETURN ] in
+  ( def @ defs,
+    List.rev fetch_fvars @ [ MK_CLOSURE ((f, None), List.length fvars) ] )
 
 let compile e =
-    let (defs, c) = comp [] e in
-    let result = c          (* body of program *)
-                 @ [HALT]   (* stop the interpreter *)
-                 @ defs in  (* the function definitions *)
-    let _ = if Option.verbose
-            then print_string ("\nCompiled Code = \n" ^ (string_of_listing result))
-            else ()
-    in result
+  let defs, c = comp [] e in
+  let result =
+    c (* body of program *) @ [ HALT ] (* stop the interpreter *) @ defs
+  in
+  (* the function definitions *)
+  let _ =
+    if Option.verbose then
+      print_string ("\nCompiled Code = \n" ^ string_of_listing result)
+    else
+      ()
+  in
+  result
 
 let interpret e = run (compile e)
-
 let reset = fun _ -> label_ref := 0

--- a/slang/jargon.mli
+++ b/slang/jargon.mli
@@ -1,12 +1,10 @@
-
 type code_index = int
 type stack_index = int
 type heap_index = int
 type static_distance = int
-type offset  = int
-
+type offset = int
 type label = string
-type location = label * (code_index option)
+type location = label * code_index option
 
 type status_code =
   | Halted
@@ -20,37 +18,31 @@ type stack_item =
   | STACK_INT of int
   | STACK_BOOL of bool
   | STACK_UNIT
-  | STACK_HI of heap_index    (* Pointer into Heap            *)
-  | STACK_RA of code_index    (* return address               *)
-  | STACK_FP of stack_index   (* Frame pointer                *)
+  | STACK_HI of heap_index (* Pointer into Heap            *)
+  | STACK_RA of code_index (* return address               *)
+  | STACK_FP of stack_index (* Frame pointer                *)
 
-type heap_type =
-    | HT_PAIR
-    | HT_INL
-    | HT_INR
-    | HT_CLOSURE
+type heap_type = HT_PAIR | HT_INL | HT_INR | HT_CLOSURE
 
 type heap_item =
   | HEAP_INT of int
   | HEAP_BOOL of bool
   | HEAP_UNIT
-  | HEAP_HI of heap_index    (* Pointer into Heap            *)
-  | HEAP_CI of code_index    (* Code pointer for closures    *)
+  | HEAP_HI of heap_index (* Pointer into Heap            *)
+  | HEAP_CI of code_index (* Code pointer for closures    *)
   | HEAP_HEADER of int * heap_type (* int is number of items to follow *)
 
-type value_path =
-  | STACK_LOCATION of offset
-  | HEAP_LOCATION of offset
+type value_path = STACK_LOCATION of offset | HEAP_LOCATION of offset
 
 type instruction =
-  | PUSH of stack_item    (* modified *)
-  | LOOKUP of value_path      (* modified *)
+  | PUSH of stack_item (* modified *)
+  | LOOKUP of value_path (* modified *)
   | UNARY of Ast.unary_oper
   | OPER of Ast.oper
   | ASSIGN
   | SWAP
   | POP
-(*  | BIND of var            not needed *)
+  (*  | BIND of var            not needed *)
   | FST
   | SND
   | DEREF
@@ -67,59 +59,43 @@ type instruction =
   | LABEL of label
   | HALT
 
-type vm_state =
-  {
-    stack_bound : stack_index;
-    code_bound  : code_index;
-    heap_bound  : code_index;
-    stack       : stack_item array;
-    heap        : heap_item array;
-    code        : instruction array;
-    mutable sp : stack_index;  (* stack pointer *)
-    mutable fp : stack_index;  (* frame pointer *)
-    mutable cp : code_index;   (* code pointer  *)
-    mutable hp : heap_index;   (* next free     *)
-    mutable status : status_code;
-  }
+type vm_state = {
+  stack_bound : stack_index;
+  code_bound : code_index;
+  heap_bound : code_index;
+  stack : stack_item array;
+  heap : heap_item array;
+  code : instruction array;
+  mutable sp : stack_index; (* stack pointer *)
+  mutable fp : stack_index; (* frame pointer *)
+  mutable cp : code_index; (* code pointer  *)
+  mutable hp : heap_index; (* next free     *)
+  mutable status : status_code;
+}
 
 val new_label : unit -> string
-			
 val step : vm_state -> vm_state
-
 val driver : int -> vm_state -> vm_state
 
 type listing = instruction list
 
-val comp : (Past.var * value_path) list ->
-           Ast.expr -> instruction list * instruction list
+val comp :
+  (Past.var * value_path) list ->
+  Ast.expr ->
+  instruction list * instruction list
 
 val compile : Ast.expr -> listing
-
 val run : listing -> vm_state
-
 val interpret : Ast.expr -> vm_state
-
 val string_of_listing : listing -> string
-
 val string_of_stack_item : stack_item -> string
-
 val string_of_status : status_code -> string
-
 val string_of_heap_item : heap_item -> string
-
 val string_of_heap_type : heap_type -> string
-
 val string_of_instruction : instruction -> string
-
 val string_of_value : vm_state -> string
-
 val string_of_location : location -> string
-
-val string_of_value_path: value_path -> string
-
+val string_of_value_path : value_path -> string
 val reset : unit -> unit
-
 val first_frame : vm_state -> vm_state
-
 val initial_state : instruction list -> vm_state
-

--- a/slang/jargon_to_x86.ml
+++ b/slang/jargon_to_x86.ml
@@ -1,5 +1,6 @@
-open Ast 
-open Jargon 
+open Ast
+open Jargon
+
 (**************************************
 Compiler Construction 2020
 Computer Laboratory
@@ -35,295 +36,326 @@ A few comments on the code below:
 -- "giria" means "slang" in Portuguese. 
 
  *****************************************)
-let complain = Errors.complain 
-  
+let complain = Errors.complain
+
 let emit_x86 e =
-    (* strip ".slang" off of filename *)
-    let base_name = String.sub Option.infile 0 ((String.length Option.infile) - 6)
-			     
-    in let out_chan = open_out (base_name ^ ".s")
-
-    in let tab c = output_string out_chan ("\t" ^ c ^ "\n")
-
+  (* strip ".slang" off of filename *)
+  let base_name =
+    String.sub Option.infile 0 (String.length Option.infile - 6)
+  in
+  let out_chan = open_out (base_name ^ ".s") in
+  let tab c =
+    output_string out_chan ("\t" ^ c ^ "\n")
     (* It would be nice to print source locations next to each line.
 		   Exercise: pass the location data while maintaining a semblence
 			 of polymorphism. 
 			 
 			 *cough* typeclasses *cough*
 		*)
-    in let cmd c comment =
-	       ((*want comments to line up nicely! *)
-		 let l = String.length c in
-		 let tab_string = if l < 8
-				 then "\t\t\t"
-				 else if l < 16
-                		 then "\t\t"
-				 else "\t" 	
-	         in output_string out_chan ("\t" ^ c ^ tab_string ^ "# " ^ comment ^"\n"))
-		 	 
-    in let label l = output_string out_chan (l ^ ":\n")
-				      
-    in let unary = function
-	 | NOT -> complain "NOT: not yet implemented in x86"
-				  
-	 | NEG -> complain "NEG: not yet implemented in x86"
-				  
-	 | READ -> (cmd "popq %rdi"    "BEGIN read, put arg in %rdi";
-		    cmd "movq $0,%rax" "signal no floating point args";
-		    cmd "pushq %r11"   "%r11 is caller-saved "; 
-		    cmd "call read"    "get user input";
-		    cmd "popq %r11"    "restore %r11"; 		    
-		    cmd "pushq %rax"   "END read, a C-call, so result in %rax \n");
+  in
+  let cmd c comment =
+    (*want comments to line up nicely! *)
+    let l = String.length c in
+    let tab_string =
+      if l < 8 then
+        "\t\t\t"
+      else if l < 16 then
+        "\t\t"
+      else
+        "\t"
+    in
+    output_string out_chan ("\t" ^ c ^ tab_string ^ "# " ^ comment ^ "\n")
+  in
+  let label l = output_string out_chan (l ^ ":\n") in
+  let unary = function
+    | NOT -> complain "NOT: not yet implemented in x86"
+    | NEG -> complain "NEG: not yet implemented in x86"
+    | READ ->
+        cmd "popq %rdi" "BEGIN read, put arg in %rdi";
+        cmd "movq $0,%rax" "signal no floating point args";
+        cmd "pushq %r11" "%r11 is caller-saved ";
+        cmd "call read" "get user input";
+        cmd "popq %r11" "restore %r11";
+        cmd "pushq %rax" "END read, a C-call, so result in %rax \n"
+  in
+  let eq () =
+    let l1 = new_label () in
+    (* label for not = *)
+    let l2 = new_label () in
+    (* label for exit *)
+    cmd "popq %rax" "BEGIN EQ, pop into %rax";
+    cmd "popq %r10" "pop into %r10";
+    cmd "cmp %r10,%rax" "compare values";
+    cmd ("jne " ^ l1) "jump if not equal";
+    cmd "pushq $1" "push true";
+    cmd ("jmp " ^ l2) "jump to exit label";
+    label l1;
+    cmd "pushq $0" "END EQ, push false \n";
+    label l2
+  in
+  let binary = function
+    | AND -> complain "AND: not yet implemented in x86"
+    | OR -> complain "OR: not yet implemented in x86"
+    | LT ->
+        let l1 = new_label () in
+        (* label for not < *)
+        let l2 = new_label () in
+        (* label for exit *)
+        cmd "popq %rax" "BEGIN equal, pop into %rax";
+        cmd "popq %r10" "pop into %r10";
+        cmd "cmp %rax,%r10" "compare values";
+        cmd ("jge " ^ l1) "jump if not(%r10 < %rax) = %rax >= %r10";
+        cmd "pushq $1" "push true";
+        cmd ("jmp " ^ l2) "jump to exit label";
+        label l1;
+        cmd "pushq $0" "END EQI, push false \n";
+        label l2
+    | EQB -> eq ()
+    | EQI -> eq ()
+    | ADD ->
+        cmd "popq %rax" "BEGIN add, pop top-of-stack to %rax";
+        cmd "addq %rax,(%rsp)" "END add, add %rax to top-of-stack \n"
+    | SUB ->
+        cmd "popq %rax" "BEGIN sub, pop top-of-stack to %rax";
+        cmd "subq %rax,(%rsp)" "END sub, subtract %rax from top-of-stack \n"
+    | MUL ->
+        cmd "popq %rax" "BEGIN mul, pop arg 1 to %rax";
+        cmd "popq %r10" "pop arg 2 to %r10";
+        cmd "imulq %r10" "multiply %r10 by %rax, result in %rax";
+        cmd "pushq %rax" "END mul, push result \n"
+    | DIV ->
+        cmd "popq %r10" "BEGIN div, , pop top-of-stack to %r10";
+        cmd "popq %rax" "pop divisor into %rax";
+        cmd "cqto" "prepare for div (read x86 docs!)";
+        cmd "idivq %r10" "do the div, result in %rax";
+        cmd "pushq %rax" "END div, push result \n"
+  in
+  let mkpair () =
+    cmd "movq %r11,%rdi" "BEGIN make pair, alloc arg 1 in %rdi";
+    cmd "movq $2,%rsi" "alloc arg 2 in %rsi";
+    cmd "movq $0,%rax" "signal no floating point args";
+    cmd "pushq %r11" "%r11 is caller-saved ";
+    cmd "call alloc" "C-call, so result in %rax";
+    cmd "popq %r11" "restore %r11";
+    cmd "popq %r10" "pop element 2 into %r10";
+    cmd "movq %r10,8(%rax)" "copy element 2 to heap";
+    cmd "popq %r10" "pop element 1 into %r10";
+    cmd "movq %r10,(%rax)" "copy element 1 to heap";
+    cmd "pushq %rax" "END make pair, push heap pointer on stack \n"
+  in
+  let fst () =
+    cmd "movq (%rsp),%rax" "BEGIN FST, copy heap pointer";
+    cmd "movq (%rax),%r10" "copy element 1 to scratch register";
+    cmd "movq %r10,(%rsp)" "END FST, replace top-of-stack with element 1 \n"
+  in
+  let snd () =
+    cmd "movq (%rsp),%rax" "BEGIN SND, copy heap pointer";
+    cmd "movq 8(%rax),%r10" "copy element 2 to scratch register";
+    cmd "movq %r10,(%rsp)" "END SND, replace top-of-stack with element 2 \n"
+  in
+  let mkinl () =
+    cmd "movq %r11,%rdi" "BEGIN make inl, alloc arg 1 in %rdi";
+    cmd "movq $2,%rsi" "alloc arg 2 in %rsi";
+    cmd "movq $0,%rax" "signal no floating point args";
+    cmd "pushq %r11" "%r11 is caller-saved ";
+    cmd "call alloc" "... result in %rax";
+    cmd "popq %r11" "restore %r11";
+    cmd "movq $0,(%rax)" "copy inl tag to the heap";
+    cmd "popq %r10" "pop argument into %r10";
+    cmd "movq %r10,8(%rax)" "copy argument to the heap";
+    cmd "pushq %rax" "END make inl, push heap pointer \n"
+  in
+  let mkinr () =
+    cmd "movq %r11,%rdi" "BEGIN make inr, alloc is a C call, arg 1 in %rdi";
+    cmd "movq $2,%rsi" "arg 2 in %rsi";
+    cmd "movq $0,%rax" "signal no floating point args";
+    cmd "pushq %r11" "%r11 is caller-saved ";
+    cmd "call alloc" "... result in %rax";
+    cmd "popq %r11" "restore %r11";
+    cmd "movq $1,(%rax)" "copy inr tag to the heap";
+    cmd "popq %r10" "pop argument into %r10";
+    cmd "movq %r10,8(%rax)" "copy argument to the heap";
+    cmd "pushq %rax" "END make inr, push heap pointer \n"
+  in
+  let case l =
+    cmd "popq %rax" "BEGIN case, pop heap pointer into %rax";
+    cmd "movq 8(%rax),%r10" "get the value";
+    cmd "pushq %r10" "push the value";
+    cmd "movq (%rax),%r10" "get tag";
+    cmd "cmpq $0,%r10" "compare tag to inl tag";
+    cmd ("jne " ^ l) "END case, jump if not equal \n"
+  in
+  let stack_lookup i =
+    (* pointers in x86-land are at byte-level, so for every word advanced
+         need to multiply by 8 (number of bytes in 64-bit word *)
+    let j = string_of_int (8 * i) in
+    cmd
+      ("movq " ^ j ^ "(%rbp)" ^ ",%r10")
+      "BEGIN stack lookup, index off of base pointer";
+    cmd "pushq %r10" "END stack lookup, push value \n"
+  in
+  let heap_lookup i =
+    let j = string_of_int (8 * i) in
+    cmd "movq 8(%rbp), %rax" "BEGIN heap lookup, copy closure pointer to %rax";
+    cmd
+      ("movq " ^ j ^ "(%rax)" ^ ",%r10")
+      ("put closue value at index " ^ string_of_int i ^ " in scratch register");
+    cmd "pushq %r10" "END heap lookup, push value \n"
+  in
+  let test l =
+    cmd "popq %rax" "BEGIN test, pop stack-top into %rax";
+    cmd "cmp $1,%rax" "compare to value of true";
+    cmd ("jne " ^ l) "END test, jump if not equal \n"
+  in
+  let goto l = cmd ("jmp " ^ l) "" in
+  let swap () =
+    cmd "movq (%rsp),%rax" "BEGIN swap";
+    cmd "movq 8(%rsp),%r10" "";
+    cmd "movq %r10,(%rsp)" "";
+    cmd "movq %rax,8(%rsp)" "END swap \n"
+  in
+  let mkref () =
+    cmd "movq %r11,%rdi" "BEGIN make ref, alloc arg 1 in %rdi";
+    cmd "movq $1,%rsi" "alloc arg 2 in %rsi";
+    cmd "movq $0,%rax" "signal no floating point args";
+    cmd "pushq %r11" "%r11 is caller-saved ";
+    cmd "call alloc" "alloc is a C-call, result in %rax";
+    cmd "popq %r11" "restore %r11";
+    cmd "popq %r10" "copy value into scratch register";
+    cmd "movq %r10,(%rax)" "copy value to heap";
+    cmd "pushq %rax" "END make ref, push heap pointer \n"
+  in
+  let deref () =
+    cmd "movq (%rsp),%rax" "BEGIN deref, copy ref pointer to $aux";
+    cmd "movq (%rax),%rax" "copy value to %rax";
+    cmd "movq %rax,(%rsp)" "END deref, replace top-of-stack with value \n"
+  in
+  let assign () =
+    cmd "popq %rax" "BEGIN assign, pop value into %rax";
+    cmd "movq %rax,(%rsp)" "copy value to ref cell in heap";
+    cmd "movq $0,(%rsp)" "END assign, replace heap pointer with unit \n"
+  in
+  let closure (l, n) =
+    let m = string_of_int (n + 1) in
+    cmd "movq %r11,%rdi" "BEGIN make closure, alloc arg 1 in %rdi";
+    cmd ("movq $" ^ m ^ ",%rsi") "arg 2 to alloc in %rsi";
+    cmd "movq $0,%rax" "signal no floating point args";
+    cmd "pushq %r11" "%r11 is caller-saved ";
+    cmd "call alloc" "... result in %rax";
+    cmd "popq %r11" "restore %r11";
+    cmd
+      ("leaq " ^ l ^ "(%rip)" ^ ",%r10")
+      "place code address in scratch register";
+    cmd "movq %r10,(%rax)" "place code address in heap closure";
+    for i = 1 to n do
+      let j = string_of_int (8 * i) in
+      cmd "popq %r10" "pop value into the scratch register";
+      cmd ("movq %r10," ^ j ^ "(%rax)") "copy value to the heap"
+    done;
+    cmd "pushq %rax" "END make closure, push heap pointer returned by alloc \n"
+  in
+  let apply () =
+    cmd "movq (%rsp),%rax" "BEGIN apply, copy closure pointer to %rax";
+    cmd "movq (%rax),%rax" "get the the function address from heap";
+    cmd "pushq %rbp" "save the frame pointer";
+    cmd "movq %rsp,%rbp" "set new frame pointer";
+    cmd "call *%rax" "call pushes return address, jumps to function";
+    cmd "popq %rbp" "retore base pointer";
+    cmd "addq $8, %rsp" "pop closure";
+    cmd "addq $8, %rsp" "pop argument";
+    cmd "pushq %rax" "END apply, push returned value on stack \n"
+  in
+  let ret () =
+    cmd "popq %rax" "BEGIN return. put top-of-stack in %rax";
+    cmd "ret" "END retrun, this pops return address, jumps there \n"
+    (* emit command *)
+  in
+  let emitc = function
+    | UNARY op -> unary op
+    | OPER op -> binary op
+    | MK_PAIR -> mkpair ()
+    | FST -> fst ()
+    | SND -> snd ()
+    | MK_INL -> mkinl ()
+    | MK_INR -> mkinr ()
+    | MK_REF -> mkref ()
+    | DEREF -> deref ()
+    | ASSIGN -> assign ()
+    | APPLY -> apply ()
+    | RETURN -> ret ()
+    | LABEL loc -> label loc
+    | SWAP -> swap ()
+    | TEST (loc, _) -> test loc
+    | GOTO (loc, _) -> goto loc
+    | CASE (loc, _) -> case loc
+    | MK_CLOSURE ((loc, _), n) -> closure (loc, n)
+    | LOOKUP (STACK_LOCATION offset) ->
+        stack_lookup (0 - offset) (* stack grows downward, so negate offsets *)
+    | LOOKUP (HEAP_LOCATION offset) -> heap_lookup offset
+    | POP -> cmd "addq $8, %rsp" "pop stack \n"
+    | PUSH (STACK_INT i) -> cmd ("pushq $" ^ string_of_int i) "push int \n"
+    | PUSH (STACK_BOOL true) -> cmd "pushq $1" "push true \n"
+    | PUSH (STACK_BOOL false) -> cmd "pushq $0" "push false \n"
+    | PUSH STACK_UNIT -> cmd "pushq $0" "push false \n"
+    | PUSH (STACK_HI _) ->
+        complain
+          "Internal Error : Jargon code never explicitly pushes stack pointer"
+    | PUSH (STACK_RA _) ->
+        complain
+          "Internal Error : Jargon code never explicitly pushes return address"
+    | PUSH (STACK_FP _) ->
+        complain
+          "Internal Error : Jargon code never explicitly pushes frame pointer"
+    | HALT -> complain "HALT found in Jargon code from Jargon.comp"
+  in
+  let rec emitl = function
+    | [] -> ()
+    | c :: l ->
+        emitc c;
+        emitl l
+  in
+  let do_command s =
+    if 0 = Sys.command s then
+      ()
+    else
+      complain ("command failed: " ^ s)
+  in
+  let defs, cl =
+    comp [] e
+    (* compile to Jargon code with Jargon.comp  *)
+  in
+  (* emit header *)
+  tab ".text";
+  tab ".extern alloc";
+  tab ".extern read";
+  tab ".globl giria";
+  tab ".type giria, @function";
 
-    in let eq () =(let l1 = new_label () in  (* label for not = *) 
-		   let l2 = new_label () in  (* label for exit *) 
-		  (cmd "popq %rax"         "BEGIN EQ, pop into %rax";
-                   cmd "popq %r10"         "pop into %r10";
-		   cmd "cmp %r10,%rax"     "compare values";
-		   cmd ("jne " ^ l1)       "jump if not equal";
-		   cmd "pushq $1"          "push true";
-		   cmd ("jmp " ^ l2)       "jump to exit label";
-		   label l1;
-		   cmd "pushq $0"          "END EQ, push false \n";
-		   label l2))
-		    
-    in let binary = function
-	 | AND -> complain "AND: not yet implemented in x86"
-				  
-	 | OR -> complain "OR: not yet implemented in x86"
-				 
-	 | LT -> (let l1 = new_label () in  (* label for not < *) 
-		  let l2 = new_label () in  (* label for exit *) 
-		  (cmd "popq %rax"         "BEGIN equal, pop into %rax";
-                   cmd "popq %r10"         "pop into %r10";
-		   cmd "cmp %rax,%r10"     "compare values";
-		   cmd ("jge " ^ l1)       "jump if not(%r10 < %rax) = %rax >= %r10";
-		   cmd "pushq $1"          "push true";
-		   cmd ("jmp " ^ l2)       "jump to exit label";
-		   label l1;
-		   cmd "pushq $0"          "END EQI, push false \n";
-		   label l2))
-		   
-	 | EQB -> eq ()
-		     
-	 | EQI -> eq ()
-		     
-	 | ADD -> (cmd "popq %rax"         "BEGIN add, pop top-of-stack to %rax"; 
-		   cmd "addq %rax,(%rsp)"  "END add, add %rax to top-of-stack \n")
-		    
-	 | SUB -> (cmd "popq %rax"         "BEGIN sub, pop top-of-stack to %rax"; 
-		   cmd "subq %rax,(%rsp)"  "END sub, subtract %rax from top-of-stack \n")
-		    
-	 | MUL -> (cmd "popq %rax"         "BEGIN mul, pop arg 1 to %rax";
-		   cmd "popq %r10"         "pop arg 2 to %r10"; 
-		   cmd "imulq %r10"        "multiply %r10 by %rax, result in %rax"; 
-		   cmd "pushq %rax"        "END mul, push result \n")
-		    
-	 | DIV -> (cmd "popq %r10"         "BEGIN div, , pop top-of-stack to %r10";
-		   cmd "popq %rax"         "pop divisor into %rax"; 
-		   cmd "cqto"              "prepare for div (read x86 docs!)";		   
-		   cmd "idivq %r10"        "do the div, result in %rax"; 
-		   cmd "pushq %rax"        "END div, push result \n")
-	   
-    in let mkpair () =
-	 (cmd "movq %r11,%rdi"        "BEGIN make pair, alloc arg 1 in %rdi"; 
-	  cmd "movq $2,%rsi"          "alloc arg 2 in %rsi";
-	  cmd "movq $0,%rax"          "signal no floating point args";
-	  cmd "pushq %r11"            "%r11 is caller-saved "; 
-	  cmd "call alloc"            "C-call, so result in %rax";
-	  cmd "popq %r11"             "restore %r11"; 		    	  
-	  cmd "popq %r10"             "pop element 2 into %r10";	  
-	  cmd "movq %r10,8(%rax)"     "copy element 2 to heap";
-	  cmd "popq %r10"             "pop element 1 into %r10";	  	  
-	  cmd "movq %r10,(%rax)"      "copy element 1 to heap";
-	  cmd "pushq %rax"            "END make pair, push heap pointer on stack \n")
-	 
-    in let fst () = (cmd "movq (%rsp),%rax"  "BEGIN FST, copy heap pointer";
-		     cmd "movq (%rax),%r10"  "copy element 1 to scratch register";
-		     cmd "movq %r10,(%rsp)"  "END FST, replace top-of-stack with element 1 \n")
-		      
-    in let snd () = (cmd "movq (%rsp),%rax"  "BEGIN SND, copy heap pointer";
-		     cmd "movq 8(%rax),%r10" "copy element 2 to scratch register";
-		     cmd "movq %r10,(%rsp)"  "END SND, replace top-of-stack with element 2 \n")
-		      
-    in let mkinl () = 
-	 (cmd "movq %r11,%rdi"        "BEGIN make inl, alloc arg 1 in %rdi"; 
-	  cmd "movq $2,%rsi"          "alloc arg 2 in %rsi";
-	  cmd "movq $0,%rax"          "signal no floating point args";
-	  cmd "pushq %r11"            "%r11 is caller-saved "; 
-	  cmd "call alloc"            "... result in %rax";
-	  cmd "popq %r11"             "restore %r11"; 		    	  	  
-	  cmd "movq $0,(%rax)"        "copy inl tag to the heap";
-	  cmd "popq %r10"             "pop argument into %r10";	  
-	  cmd "movq %r10,8(%rax)"     "copy argument to the heap";
-	  cmd "pushq %rax"            "END make inl, push heap pointer \n")
+  output_string out_chan "giria:\n";
 
-   in let mkinr () =
-	 (cmd "movq %r11,%rdi"        "BEGIN make inr, alloc is a C call, arg 1 in %rdi";
-	  cmd "movq $2,%rsi"          "arg 2 in %rsi";
-	  cmd "movq $0,%rax"          "signal no floating point args";
-	  cmd "pushq %r11"            "%r11 is caller-saved "; 
-	  cmd "call alloc"            "... result in %rax";
-	  cmd "popq %r11"             "restore %r11"; 		    	  	  
-	  cmd "movq $1,(%rax)"        "copy inr tag to the heap";
-	  cmd "popq %r10"             "pop argument into %r10";	  	  
-	  cmd "movq %r10,8(%rax)"     "copy argument to the heap";
-	  cmd "pushq %rax"            "END make inr, push heap pointer \n")
+  (* label for main body of slang program *)
+  cmd "pushq %rbp" "BEGIN giria : save base pointer";
+  cmd "movq %rsp,%rbp" "BEGIN giria : set new base pointer";
+  cmd "movq %rdi,%r11" "BEGIN giria : save pointer to heap in %r11 \n";
 
-   in let case l =
-	(cmd "popq %rax"            "BEGIN case, pop heap pointer into %rax";
-	 cmd "movq 8(%rax),%r10"    "get the value";
-	 cmd "pushq %r10"           "push the value"; 	 	 
-	 cmd "movq (%rax),%r10"     "get tag"; 
-	 cmd "cmpq $0,%r10"         "compare tag to inl tag"; 
-	 cmd ("jne " ^ l)           "END case, jump if not equal \n")
+  emitl cl;
 
-  in let stack_lookup i =
-      (* pointers in x86-land are at byte-level, so for every word advanced
-         need to multiply by 8 (number of bytes in 64-bit word *)	    
-	(let j = string_of_int (8 * i) in  	   	    
-         (cmd ("movq " ^ j ^ "(%rbp)" ^ ",%r10") "BEGIN stack lookup, index off of base pointer";
-	  cmd "pushq %r10"                       "END stack lookup, push value \n"))
-	                        
-   in let heap_lookup i =
-	(let j = string_of_int (8 * i) in  	   
-	 (cmd "movq 8(%rbp), %rax"               "BEGIN heap lookup, copy closure pointer to %rax";
- 	  cmd ("movq " ^ j ^ "(%rax)" ^ ",%r10") ("put closue value at index " ^ (string_of_int i) ^ " in scratch register");
-	  cmd "pushq %r10"                       "END heap lookup, push value \n"))
+  (* main body of program *)
+  cmd "popq %rax" "END giria : place return value in %rax";
+  cmd "movq %rbp,%rsp" "END giria : reset stack to previous base pointer";
+  cmd "popq %rbp" "END giria : restore base pointer";
+  cmd "ret" "END giria : return to runtime system \n";
 
-   in let test l = 
-	(cmd "popq %rax"            "BEGIN test, pop stack-top into %rax";
-	 cmd "cmp $1,%rax"          "compare to value of true"; 
-	 cmd ("jne " ^ l)           "END test, jump if not equal \n")
+  emitl defs;
 
-   in let goto l = cmd ("jmp " ^ l) ""
-			  
-   in let swap () =
-	 (cmd "movq (%rsp),%rax"      "BEGIN swap";
-	  cmd "movq 8(%rsp),%r10"      "";
-	  cmd "movq %r10,(%rsp)"       "";	  
-	  cmd "movq %rax,8(%rsp)"     "END swap \n")
-	   
-   in let mkref () =
-	 (cmd "movq %r11,%rdi"        "BEGIN make ref, alloc arg 1 in %rdi";        
-	  cmd "movq $1,%rsi"          "alloc arg 2 in %rsi";
-	  cmd "movq $0,%rax"          "signal no floating point args";
-	  cmd "pushq %r11"            "%r11 is caller-saved "; 
-	  cmd "call alloc"            "alloc is a C-call, result in %rax";
-	  cmd "popq %r11"             "restore %r11"; 		    	  	  
-	  cmd "popq %r10"             "copy value into scratch register"; 	  
-	  cmd "movq %r10,(%rax)"      "copy value to heap"; 
-	  cmd "pushq %rax"            "END make ref, push heap pointer \n")
-	   
-    in let deref () =
-	 (cmd "movq (%rsp),%rax"      "BEGIN deref, copy ref pointer to $aux";
-   	  cmd "movq (%rax),%rax"      "copy value to %rax"; 
-   	  cmd "movq %rax,(%rsp)"      "END deref, replace top-of-stack with value \n")
-	   
-    in let assign () =
-	 (cmd "popq %rax"          "BEGIN assign, pop value into %rax";
-	  cmd "movq %rax,(%rsp)"   "copy value to ref cell in heap";
-      	  cmd "movq $0,(%rsp)"     "END assign, replace heap pointer with unit \n")
+  (* the function definitions *)
+  flush out_chan;
+  close_out out_chan;
 
-    in let closure(l, n) =
-	(let m = string_of_int (n + 1) in 
-	 (cmd "movq %r11,%rdi"                   "BEGIN make closure, alloc arg 1 in %rdi"; 
-	  cmd ("movq $" ^ m ^ ",%rsi")           "arg 2 to alloc in %rsi";
-	  cmd "movq $0,%rax"                     "signal no floating point args";
-	  cmd "pushq %r11"                       "%r11 is caller-saved ";	  
-	  cmd "call alloc"                       "... result in %rax";
-	  cmd "popq %r11"                        "restore %r11"; 		    	  	  
-	  cmd ("leaq " ^ l ^ "(%rip)" ^ ",%r10") "place code address in scratch register";
-	  cmd ("movq %r10,(%rax)")               "place code address in heap closure";
-   	  for i = 1 to n do
-	    let j = string_of_int (8 * i) in  
-	    (cmd ("popq %r10")                   "pop value into the scratch register";
-	     cmd ("movq %r10," ^ j ^ "(%rax)")   "copy value to the heap")
-	  done; 
-	  cmd "pushq %rax"                       "END make closure, push heap pointer returned by alloc \n"))
-	      
-	      
-    in let apply () =
-	    (cmd "movq (%rsp),%rax"   "BEGIN apply, copy closure pointer to %rax";
-             cmd "movq (%rax),%rax"   "get the the function address from heap";	  
-	     cmd "pushq %rbp"         "save the frame pointer";
-	     cmd "movq %rsp,%rbp"     "set new frame pointer";	     	     
-      	     cmd "call *%rax"         "call pushes return address, jumps to function";
-	     cmd "popq %rbp"          "retore base pointer";	     
-	     cmd "addq $8, %rsp"      "pop closure";
-	     cmd "addq $8, %rsp"      "pop argument";
-	     cmd "pushq %rax"         "END apply, push returned value on stack \n")
-	      
-    in let ret () = 
-	    (cmd "popq %rax"         "BEGIN return. put top-of-stack in %rax";
-      	     cmd "ret"               "END retrun, this pops return address, jumps there \n")
-	    
-    (* emit command *) 	    
-    in let emitc = function
-	  | UNARY op -> unary op
-	  | OPER op  -> binary op
-	  | MK_PAIR  -> mkpair ()
-	  | FST      -> fst()
-	  | SND      -> snd()
-	  | MK_INL   -> mkinl()
-	  | MK_INR   -> mkinr()
-	  | MK_REF   -> mkref()
-	  | DEREF    -> deref()
-	  | ASSIGN   -> assign()
-	  | APPLY    -> apply ()
-	  | RETURN   -> ret()
-	  | LABEL loc  -> label loc
-	  | SWAP     -> swap ()
-	  | TEST (loc, _) -> test loc
-	  | GOTO (loc, _) -> goto loc
-	  | CASE (loc, _) -> case loc
-	  | MK_CLOSURE ((loc, _), n)         -> closure(loc, n)
-	  | LOOKUP (STACK_LOCATION offset) -> stack_lookup (0 - offset) (* stack grows downward, so negate offsets *)
-	  | LOOKUP (HEAP_LOCATION offset)  -> heap_lookup offset
-	  | POP                     -> cmd "addq $8, %rsp" "pop stack \n"
-	  | PUSH (STACK_INT i)      -> cmd ("pushq $" ^ (string_of_int i)) "push int \n"
-	  | PUSH (STACK_BOOL true)  -> cmd "pushq $1" "push true \n"
-	  | PUSH (STACK_BOOL false) -> cmd "pushq $0" "push false \n"
-	  | PUSH (STACK_UNIT)         -> cmd "pushq $0" "push false \n"
-	  | PUSH (STACK_HI _)       -> complain "Internal Error : Jargon code never explicitly pushes stack pointer"
-	  | PUSH (STACK_RA _)       -> complain "Internal Error : Jargon code never explicitly pushes return address"
-	  | PUSH (STACK_FP _)       -> complain "Internal Error : Jargon code never explicitly pushes frame pointer"
-	  | HALT                  -> complain "HALT found in Jargon code from Jargon.comp"
-
-    in let rec emitl = function [] -> () | c::l -> (emitc c; emitl l)
-
-    in let do_command s = if 0 = Sys.command s then () else complain ("command failed: " ^ s) 
-    
-    in let (defs, cl) = comp [] e           (* compile to Jargon code with Jargon.comp  *) 						     
-       in (* emit header *)
-       (tab ".text";
-        tab ".extern alloc" ;
-	tab ".extern read";
-	tab ".globl giria";
-	tab ".type giria, @function";
-
-	output_string out_chan "giria:\n";  (* label for main body of slang program *)
-	
-	cmd "pushq %rbp"	"BEGIN giria : save base pointer"; 
-	cmd "movq %rsp,%rbp"    "BEGIN giria : set new base pointer";
-	cmd "movq %rdi,%r11"    "BEGIN giria : save pointer to heap in %r11 \n";
-	
-	emitl cl;               (* main body of program *)
-	
-	cmd "popq %rax"         "END giria : place return value in %rax"; 
-	cmd "movq %rbp,%rsp"	"END giria : reset stack to previous base pointer";   
-	cmd "popq %rbp"	        "END giria : restore base pointer";
-	cmd "ret"               "END giria : return to runtime system \n";
-
-        emitl defs;             (* the function definitions *)
-	
-        flush out_chan;
-        close_out out_chan;
-	
-	(* compile and link with runtime.  Comment out these lines if you don't have gcc installed. *)
-	do_command "gcc -g -o runtime/c_runtime.o -c runtime/c_runtime.c"; 
-        do_command ("gcc -g -o " ^ base_name ^ ".o -c " ^ base_name ^ ".s");
-        do_command ("gcc -g -o " ^ base_name ^ " runtime/c_runtime.o " ^ base_name ^ ".o"); 
-        do_command ("rm " ^ base_name ^ ".o");
-	()
-       )
+  (* compile and link with runtime.  Comment out these lines if you don't have gcc installed. *)
+  do_command "gcc -g -o runtime/c_runtime.o -c runtime/c_runtime.c";
+  do_command ("gcc -g -o " ^ base_name ^ ".o -c " ^ base_name ^ ".s");
+  do_command
+    ("gcc -g -o " ^ base_name ^ " runtime/c_runtime.o " ^ base_name ^ ".o");
+  do_command ("rm " ^ base_name ^ ".o");
+  ()

--- a/slang/option.ml
+++ b/slang/option.ml
@@ -1,44 +1,56 @@
 (*
    parse command line options and args
 *)
-let infile         = ref ""
-let verbose        = ref false
-let verbose_front  = ref false
-let verbose_tree  = ref false
-let run_tests      = ref false
-let use_i0         = ref false
-let use_i1         = ref false
-let use_i2         = ref false
-let use_i3         = ref false
-let use_i4         = ref false
-let use_i4x86      = ref false			 
-let use_all ()     =
-   use_i0 := true;
-   use_i1 := true;
-   use_i2 := true;
-   use_i3 := true;
-   use_i4 := true
-let show_compiled  = ref false
-let set_infile f   = infile := f
-let stack_max      = ref 1000
-let heap_max       = ref 1000
+let infile = ref ""
+let verbose = ref false
+let verbose_front = ref false
+let verbose_tree = ref false
+let run_tests = ref false
+let use_i0 = ref false
+let use_i1 = ref false
+let use_i2 = ref false
+let use_i3 = ref false
+let use_i4 = ref false
+let use_i4x86 = ref false
 
-let option_spec = [
-     ("-V",    Arg.Set verbose_front, "verbose front end");
-     ("-v",    Arg.Set verbose,       "verbose interpreter(s)");
-     ("-T",    Arg.Set verbose_tree,       "verbose output in the form of tree (currently only frontend)");
-     ("-c",    Arg.Set show_compiled, "show compiled code (but don't run it)");
-     ("-i0",   Arg.Set use_i0,        "Interpreter 0");
-     ("-i1",   Arg.Set use_i1,        "Interpreter 1" );
-     ("-i2",   Arg.Set use_i2,        "Interpreter 2" );
-     ("-i3",   Arg.Set use_i3,        "Interpreter 3" );
-     ("-i4",   Arg.Set use_i4,        "Jargon VM" );
-     ("-i4x86", Arg.Set use_i4x86,    "Jargon code to x86: foo.slang generates x86 code in foo.s and executable in foo" );     
-     ("-all",  Arg.Unit use_all,      "all interpreters");
-     ("-stackmax",  Arg.Set_int stack_max, "set max stack size (default = 1000)");
-     ("-heapmax",  Arg.Set_int heap_max, "set max heap size (default = 1000)");
-     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)")
-    ]
+let use_all () =
+  use_i0 := true;
+  use_i1 := true;
+  use_i2 := true;
+  use_i3 := true;
+  use_i4 := true
+
+let show_compiled = ref false
+let set_infile f = infile := f
+let stack_max = ref 1000
+let heap_max = ref 1000
+
+let option_spec =
+  [
+    ("-V", Arg.Set verbose_front, "verbose front end");
+    ("-v", Arg.Set verbose, "verbose interpreter(s)");
+    ( "-T",
+      Arg.Set verbose_tree,
+      "verbose output in the form of tree (currently only frontend)" );
+    ("-c", Arg.Set show_compiled, "show compiled code (but don't run it)");
+    ("-i0", Arg.Set use_i0, "Interpreter 0");
+    ("-i1", Arg.Set use_i1, "Interpreter 1");
+    ("-i2", Arg.Set use_i2, "Interpreter 2");
+    ("-i3", Arg.Set use_i3, "Interpreter 3");
+    ("-i4", Arg.Set use_i4, "Jargon VM");
+    ( "-i4x86",
+      Arg.Set use_i4x86,
+      "Jargon code to x86: foo.slang generates x86 code in foo.s and \
+       executable in foo" );
+    ("-all", Arg.Unit use_all, "all interpreters");
+    ("-stackmax", Arg.Set_int stack_max, "set max stack size (default = 1000)");
+    ("-heapmax", Arg.Set_int heap_max, "set max heap size (default = 1000)");
+    ( "-t",
+      Arg.Set run_tests,
+      "run all test/*.slang with each selected interpreter, report unexpected \
+       outputs (silent otherwise)" );
+  ]
+
 let usage_msg = "Usage: slang.byte [options] [<file>]\nOptions are:"
 
 (* This does the parsing and *)
@@ -46,17 +58,17 @@ let () = Arg.parse option_spec set_infile usage_msg
 
 (* set immutable versions of the options now that they have been parsed 
  * Note: this is only to make the interface cleaner. *)
-let infile        = !infile
-let verbose       = !verbose
+let infile = !infile
+let verbose = !verbose
 let verbose_front = !verbose_front
 let verbose_tree = !verbose_tree
-let run_tests     = !run_tests
-let use_i0        = !use_i0
-let use_i1        = !use_i1
-let use_i2        = !use_i2
-let use_i3        = !use_i3
-let use_i4        = !use_i4
-let use_i4x86     = !use_i4x86		     
+let run_tests = !run_tests
+let use_i0 = !use_i0
+let use_i1 = !use_i1
+let use_i2 = !use_i2
+let use_i3 = !use_i3
+let use_i4 = !use_i4
+let use_i4x86 = !use_i4x86
 let show_compiled = !show_compiled
-let stack_max     = !stack_max
-let heap_max      = !heap_max
+let stack_max = !stack_max
+let heap_max = !heap_max

--- a/slang/option.mli
+++ b/slang/option.mli
@@ -1,16 +1,15 @@
-
 (* These are all the options parsed by the module *)
-val infile: string
-val verbose: bool
-val verbose_front: bool
-val verbose_tree: bool
-val run_tests: bool
-val use_i0: bool
-val use_i1: bool
-val use_i2: bool
-val use_i3: bool
-val use_i4: bool
-val use_i4x86: bool	
-val show_compiled: bool
-val stack_max: int
-val heap_max: int
+val infile : string
+val verbose : bool
+val verbose_front : bool
+val verbose_tree : bool
+val run_tests : bool
+val use_i0 : bool
+val use_i1 : bool
+val use_i2 : bool
+val use_i3 : bool
+val use_i4 : bool
+val use_i4x86 : bool
+val show_compiled : bool
+val stack_max : int
+val heap_max : int

--- a/slang/past.ml
+++ b/slang/past.ml
@@ -2,84 +2,81 @@
 
    The Parsed AST 
 
-*) 
-type var = string 
+*)
+type var = string
+type loc = Lexing.position
 
-type loc = Lexing.position 
-
-type type_expr = 
-   | TEint
-   | TEbool 
-   | TEunit 
-   | TEref of type_expr 
-   | TEarrow of type_expr * type_expr
-   | TEproduct of type_expr * type_expr
-   | TEunion of type_expr * type_expr
+type type_expr =
+  | TEint
+  | TEbool
+  | TEunit
+  | TEref of type_expr
+  | TEarrow of type_expr * type_expr
+  | TEproduct of type_expr * type_expr
+  | TEunion of type_expr * type_expr
 
 type oper = ADD | MUL | DIV | SUB | LT | AND | OR | EQ | EQB | EQI
+type unary_oper = NEG | NOT
 
-type unary_oper = NEG | NOT 
+type expr =
+  | Unit of loc
+  | What of loc
+  | Var of loc * var
+  | Integer of loc * int
+  | Boolean of loc * bool
+  | UnaryOp of loc * unary_oper * expr
+  | Op of loc * expr * oper * expr
+  | If of loc * expr * expr * expr
+  | Pair of loc * expr * expr
+  | Fst of loc * expr
+  | Snd of loc * expr
+  | Inl of loc * type_expr * expr
+  | Inr of loc * type_expr * expr
+  | Case of loc * expr * lambda * lambda
+  | While of loc * expr * expr
+  | Seq of loc * expr list
+  | Ref of loc * expr
+  | Deref of loc * expr
+  | Assign of loc * expr * expr
+  | Lambda of loc * lambda
+  | App of loc * expr * expr
+  | Let of loc * var * type_expr * expr * expr
+  | LetFun of loc * var * lambda * type_expr * expr
+  | LetRecFun of loc * var * lambda * type_expr * expr
 
-type expr = 
-       | Unit of loc  
-       | What of loc 
-       | Var of loc * var
-       | Integer of loc * int
-       | Boolean of loc * bool
-       | UnaryOp of loc * unary_oper * expr
-       | Op of loc * expr * oper * expr
-       | If of loc * expr * expr * expr
-       | Pair of loc * expr * expr
-       | Fst of loc * expr 
-       | Snd of loc * expr 
-       | Inl of loc * type_expr * expr 
-       | Inr of loc * type_expr * expr 
-       | Case of loc * expr * lambda * lambda 
+and lambda = var * type_expr * expr
 
-       | While of loc * expr * expr 
-       | Seq of loc * (expr list)
-       | Ref of loc * expr 
-       | Deref of loc * expr 
-       | Assign of loc * expr * expr
+let loc_of_expr = function
+  | Unit loc -> loc
+  | What loc -> loc
+  | Var (loc, _) -> loc
+  | Integer (loc, _) -> loc
+  | Boolean (loc, _) -> loc
+  | UnaryOp (loc, _, _) -> loc
+  | Op (loc, _, _, _) -> loc
+  | If (loc, _, _, _) -> loc
+  | Pair (loc, _, _) -> loc
+  | Fst (loc, _) -> loc
+  | Snd (loc, _) -> loc
+  | Inr (loc, _, _) -> loc
+  | Inl (loc, _, _) -> loc
+  | Case (loc, _, _, _) -> loc
+  | Seq (loc, _) -> loc
+  | Ref (loc, _) -> loc
+  | Deref (loc, _) -> loc
+  | Assign (loc, _, _) -> loc
+  | While (loc, _, _) -> loc
+  | Lambda (loc, _) -> loc
+  | App (loc, _, _) -> loc
+  | Let (loc, _, _, _, _) -> loc
+  | LetFun (loc, _, _, _, _) -> loc
+  | LetRecFun (loc, _, _, _, _) -> loc
 
-       | Lambda of loc * lambda 
-       | App of loc * expr * expr
-       | Let of loc * var * type_expr * expr * expr
-       | LetFun of loc * var * lambda * type_expr * expr
-       | LetRecFun of loc * var * lambda * type_expr * expr
-
-and lambda = var * type_expr * expr 
-
-let  loc_of_expr = function 
-    | Unit loc                      -> loc 
-    | What loc                      -> loc 
-    | Var (loc, _)                  -> loc 
-    | Integer (loc, _)              -> loc 
-    | Boolean (loc, _)              -> loc 
-    | UnaryOp(loc, _, _)            -> loc 
-    | Op(loc, _, _, _)              -> loc 
-    | If(loc, _, _, _)              -> loc 
-    | Pair(loc, _, _)               -> loc 
-    | Fst(loc, _)                   -> loc 
-    | Snd(loc, _)                   -> loc 
-    | Inr(loc, _, _)                -> loc 
-    | Inl(loc, _, _)                -> loc 
-    | Case(loc, _, _, _)            -> loc 
-    | Seq(loc, _)                   -> loc 
-    | Ref(loc, _)                   -> loc 
-    | Deref(loc, _)                 -> loc 
-    | Assign(loc, _, _)             -> loc 
-    | While(loc, _, _)              -> loc 
-    | Lambda(loc, _)                -> loc 
-    | App(loc, _, _)                -> loc 
-    | Let(loc, _, _, _, _)          -> loc 
-    | LetFun(loc, _, _, _, _)       -> loc 
-    | LetRecFun(loc, _, _, _, _)    -> loc 
-
-
-let string_of_loc loc = 
-    "line " ^ (string_of_int (loc.Lexing.pos_lnum)) ^ ", " ^ 
-    "position " ^ (string_of_int ((loc.Lexing.pos_cnum - loc.Lexing.pos_bol) + 1))
+let string_of_loc loc =
+  "line "
+  ^ string_of_int loc.Lexing.pos_lnum
+  ^ ", " ^ "position "
+  ^ string_of_int (loc.Lexing.pos_cnum - loc.Lexing.pos_bol + 1)
 
 open Format
 
@@ -87,165 +84,177 @@ open Format
    Documentation of Format can be found here: 
    http://caml.inria.fr/resources/doc/guides/format.en.html
    http://caml.inria.fr/pub/docs/manual-ocaml/libref/Format.html
-*) 
+*)
 
-let rec pp_type = function 
-  | TEint -> "int" 
-  | TEbool -> "bool" 
-  | TEunit -> "unit" 
-  | TEref t           -> "(" ^ (pp_type t) ^ " ref)"
-  | TEarrow(t1, t2)   -> "(" ^ (pp_type t1) ^ " -> " ^ (pp_type t2) ^ ")" 
-  | TEproduct(t1, t2) -> "(" ^ (pp_type t1) ^ " * " ^ (pp_type t2) ^ ")"  
-  | TEunion(t1, t2)   -> "(" ^ (pp_type t1) ^ " + " ^ (pp_type t2) ^ ")"  
+let rec pp_type = function
+  | TEint -> "int"
+  | TEbool -> "bool"
+  | TEunit -> "unit"
+  | TEref t -> "(" ^ pp_type t ^ " ref)"
+  | TEarrow (t1, t2) -> "(" ^ pp_type t1 ^ " -> " ^ pp_type t2 ^ ")"
+  | TEproduct (t1, t2) -> "(" ^ pp_type t1 ^ " * " ^ pp_type t2 ^ ")"
+  | TEunion (t1, t2) -> "(" ^ pp_type t1 ^ " + " ^ pp_type t2 ^ ")"
 
-let pp_uop = function 
-  | NEG -> "-" 
-  | NOT -> "~" 
+let pp_uop = function NEG -> "-" | NOT -> "~"
 
+let pp_bop = function
+  | ADD -> "+"
+  | MUL -> "*"
+  | DIV -> "/"
+  | SUB -> "-"
+  | LT -> "<"
+  | EQ -> "="
+  | EQI -> "eqi"
+  | EQB -> "eqb"
+  | AND -> "&&"
+  | OR -> "||"
 
-let pp_bop = function 
-  | ADD -> "+" 
-  | MUL  -> "*" 
-  | DIV  -> "/" 
-  | SUB -> "-" 
-  | LT   -> "<" 
-  | EQ   -> "=" 
-  | EQI   -> "eqi" 
-  | EQB   -> "eqb" 
-  | AND   -> "&&" 
-  | OR   -> "||" 
-
-let string_of_oper = pp_bop 
-let string_of_unary_oper = pp_uop 
-
+let string_of_oper = pp_bop
+let string_of_unary_oper = pp_uop
 let fstring ppf s = fprintf ppf "%s" s
-let pp_type ppf t = fstring ppf (pp_type t) 
-let pp_unary ppf op = fstring ppf (pp_uop op) 
-let pp_binary ppf op = fstring ppf (pp_bop op) 
+let pp_type ppf t = fstring ppf (pp_type t)
+let pp_unary ppf op = fstring ppf (pp_uop op)
+let pp_binary ppf op = fstring ppf (pp_bop op)
 
-(* ignore locations *) 
-let rec pp_expr ppf = function 
-    | Unit _              -> fstring ppf "()" 
-    | What _              -> fstring ppf "?" 
-    | Var (_, x)          -> fstring ppf x 
-    | Integer (_, n)      -> fstring ppf (string_of_int n)
-    | Boolean (_, b)      -> fstring ppf (string_of_bool b)
-    | UnaryOp(_, op, e)   -> fprintf ppf "%a(%a)" pp_unary op pp_expr e 
-    | Op(_, e1, op, e2)   -> fprintf ppf "(%a %a %a)" pp_expr e1  pp_binary op pp_expr e2 
-    | If(_, e1, e2, e3)   -> fprintf ppf "@[if %a then %a else %a @]" 
-                                      pp_expr e1 pp_expr e2 pp_expr e3
-    | Pair(_, e1, e2)     -> fprintf ppf "(%a, %a)" pp_expr e1 pp_expr e2
-    | Fst(_, e)           -> fprintf ppf "fst(%a)" pp_expr e
-    | Snd(_, e)           -> fprintf ppf "snd %a" pp_expr e
-    | Inl(_, t, e)        -> fprintf ppf "(inl %a %a)" pp_type t pp_expr e
-    | Inr(_, t, e)        -> fprintf ppf "(inr %a %a)" pp_type t pp_expr e
-    | Case(_, e, (x1, t1, e1), (x2, t2, e2)) -> 
-        fprintf ppf "@[<2>case %a of@ | inl(%a : %a) -> %a @ | inr(%a : %a) -> %a end@]" 
-                     pp_expr e fstring x1 pp_type t1 pp_expr e1 fstring x2 pp_type t2 pp_expr e2 
+(* ignore locations *)
+let rec pp_expr ppf = function
+  | Unit _ -> fstring ppf "()"
+  | What _ -> fstring ppf "?"
+  | Var (_, x) -> fstring ppf x
+  | Integer (_, n) -> fstring ppf (string_of_int n)
+  | Boolean (_, b) -> fstring ppf (string_of_bool b)
+  | UnaryOp (_, op, e) -> fprintf ppf "%a(%a)" pp_unary op pp_expr e
+  | Op (_, e1, op, e2) ->
+      fprintf ppf "(%a %a %a)" pp_expr e1 pp_binary op pp_expr e2
+  | If (_, e1, e2, e3) ->
+      fprintf ppf "@[if %a then %a else %a @]" pp_expr e1 pp_expr e2 pp_expr e3
+  | Pair (_, e1, e2) -> fprintf ppf "(%a, %a)" pp_expr e1 pp_expr e2
+  | Fst (_, e) -> fprintf ppf "fst(%a)" pp_expr e
+  | Snd (_, e) -> fprintf ppf "snd %a" pp_expr e
+  | Inl (_, t, e) -> fprintf ppf "(inl %a %a)" pp_type t pp_expr e
+  | Inr (_, t, e) -> fprintf ppf "(inr %a %a)" pp_type t pp_expr e
+  | Case (_, e, (x1, t1, e1), (x2, t2, e2)) ->
+      fprintf ppf
+        "@[<2>case %a of@ | inl(%a : %a) -> %a @ | inr(%a : %a) -> %a end@]"
+        pp_expr e fstring x1 pp_type t1 pp_expr e1 fstring x2 pp_type t2 pp_expr
+        e2
+  | Seq (_, []) -> ()
+  | Seq (_, [ e ]) -> pp_expr ppf e
+  | Seq (l, e :: rest) -> fprintf ppf "%a; %a" pp_expr e pp_expr (Seq (l, rest))
+  | While (_, e1, e2) -> fprintf ppf "while %a do %a end" pp_expr e1 pp_expr e2
+  | Ref (_, e) -> fprintf ppf "ref %a" pp_expr e
+  | Deref (_, e) -> fprintf ppf "!%a" pp_expr e
+  | Assign (_, e1, e2) -> fprintf ppf "(%a := %a)" pp_expr e1 pp_expr e2
+  | Lambda (_, (x, t, e)) ->
+      fprintf ppf "(fun %a : %a -> %a)" fstring x pp_type t pp_expr e
+  | App (_, e1, e2) -> fprintf ppf "%a %a" pp_expr e1 pp_expr e2
+  | Let (_, x, t, e1, e2) ->
+      fprintf ppf "@[<2>let %a : %a = %a in %a end@]" fstring x pp_type t
+        pp_expr e1 pp_expr e2
+  | LetFun (_, f, (x, t1, e1), t2, e2) ->
+      fprintf ppf "@[let %a(%a : %a) : %a =@ %a @ in %a @ end@]" fstring f
+        fstring x pp_type t1 pp_type t2 pp_expr e1 pp_expr e2
+  | LetRecFun (_, f, (x, t1, e1), t2, e2) ->
+      fprintf ppf "@[letrec %a(%a : %a) : %a =@ %a @ in %a @ end@]" fstring f
+        fstring x pp_type t1 pp_type t2 pp_expr e1 pp_expr e2
 
-    | Seq (_, [])         -> () 
-    | Seq (_, [e])        -> pp_expr ppf e 
-    | Seq (l, e :: rest)  -> fprintf ppf "%a; %a" pp_expr e pp_expr (Seq(l, rest))
-    | While (_, e1, e2)   -> fprintf ppf "while %a do %a end" pp_expr e1 pp_expr e2 
-    | Ref(_, e)           -> fprintf ppf "ref %a" pp_expr e
-    | Deref(_, e)         -> fprintf ppf "!%a" pp_expr e
-    | Assign(_, e1, e2)   -> fprintf ppf "(%a := %a)" pp_expr e1 pp_expr e2 
-    | Lambda(_, (x, t, e)) -> 
-         fprintf ppf "(fun %a : %a -> %a)" fstring x pp_type t  pp_expr e
-    | App(_, e1, e2)      -> fprintf ppf "%a %a" pp_expr e1 pp_expr e2
-    | Let(_, x, t, e1, e2) -> 
-         fprintf ppf "@[<2>let %a : %a = %a in %a end@]" fstring x pp_type t pp_expr e1 pp_expr e2
-    | LetFun(_, f, (x, t1, e1), t2, e2)     -> 
-         fprintf ppf "@[let %a(%a : %a) : %a =@ %a @ in %a @ end@]" 
-                     fstring f fstring x  pp_type t1 pp_type t2 pp_expr e1 pp_expr e2
-    | LetRecFun(_, f, (x, t1, e1), t2, e2)     -> 
-         fprintf ppf "@[letrec %a(%a : %a) : %a =@ %a @ in %a @ end@]" 
-                     fstring f fstring x  pp_type t1 pp_type t2 pp_expr e1 pp_expr e2
+let print_expr e =
+  let _ = pp_expr std_formatter e in
+  print_flush ()
 
-let print_expr e = 
-    let _ = pp_expr std_formatter e
-    in print_flush () 
+let eprint_expr e =
+  let _ = pp_expr err_formatter e in
+  print_flush ()
 
-let eprint_expr e = 
-    let _ = pp_expr err_formatter e
-    in print_flush () 
+(* useful for degugging *)
 
-(* useful for degugging *) 
+let string_of_uop = function NEG -> "NEG" | NOT -> "NOT"
 
+let string_of_bop = function
+  | ADD -> "ADD"
+  | MUL -> "MUL"
+  | DIV -> "DIV"
+  | SUB -> "SUB"
+  | LT -> "LT"
+  | EQ -> "EQ"
+  | EQI -> "EQI"
+  | EQB -> "EQB"
+  | AND -> "AND"
+  | OR -> "OR"
 
-let string_of_uop = function 
-  | NEG -> "NEG" 
-  | NOT -> "NOT" 
+let mk_con con l =
+  let rec aux carry = function
+    | [] -> carry ^ ")"
+    | [ s ] -> carry ^ s ^ ")"
+    | s :: rest -> aux (carry ^ s ^ ", ") rest
+  in
+  aux (con ^ "(") l
 
-let string_of_bop = function 
-  | ADD -> "ADD" 
-  | MUL  -> "MUL" 
-  | DIV  -> "DIV" 
-  | SUB -> "SUB" 
-  | LT   -> "LT" 
-  | EQ   -> "EQ" 
-  | EQI   -> "EQI" 
-  | EQB   -> "EQB" 
-  | AND   -> "AND" 
-  | OR   -> "OR" 
+let rec string_of_type = function
+  | TEint -> "TEint"
+  | TEbool -> "TEbool"
+  | TEunit -> "TEunit"
+  | TEref t -> mk_con "TEref" [ string_of_type t ]
+  | TEarrow (t1, t2) ->
+      mk_con "TEarrow" [ string_of_type t1; string_of_type t2 ]
+  | TEproduct (t1, t2) ->
+      mk_con "TEproduct" [ string_of_type t1; string_of_type t2 ]
+  | TEunion (t1, t2) ->
+      mk_con "TEunion" [ string_of_type t1; string_of_type t2 ]
 
-let mk_con con l = 
-    let rec aux carry = function 
-      | [] -> carry ^ ")"
-      | [s] -> carry ^ s ^ ")"
-      | s::rest -> aux (carry ^ s ^ ", ") rest 
-    in aux (con ^ "(") l 
+let rec string_of_expr = function
+  | Unit _ -> "Unit"
+  | What _ -> "What"
+  | Var (_, x) -> mk_con "Var" [ x ]
+  | Integer (_, n) -> mk_con "Integer" [ string_of_int n ]
+  | Boolean (_, b) -> mk_con "Boolean" [ string_of_bool b ]
+  | UnaryOp (_, op, e) ->
+      mk_con "UnaryOp" [ string_of_uop op; string_of_expr e ]
+  | Op (_, e1, op, e2) ->
+      mk_con "Op" [ string_of_expr e1; string_of_bop op; string_of_expr e2 ]
+  | If (_, e1, e2, e3) ->
+      mk_con "If" [ string_of_expr e1; string_of_expr e2; string_of_expr e3 ]
+  | Pair (_, e1, e2) -> mk_con "Pair" [ string_of_expr e1; string_of_expr e2 ]
+  | Fst (_, e) -> mk_con "Fst" [ string_of_expr e ]
+  | Snd (_, e) -> mk_con "Snd" [ string_of_expr e ]
+  | Inl (_, _, e) -> mk_con "Inl" [ string_of_expr e ]
+  | Inr (_, _, e) -> mk_con "Inr" [ string_of_expr e ]
+  | Seq (_, el) -> mk_con "Seq" [ string_of_expr_list el ]
+  | While (_, e1, e2) -> mk_con "While" [ string_of_expr e1; string_of_expr e2 ]
+  | Ref (_, e) -> mk_con "Ref" [ string_of_expr e ]
+  | Deref (_, e) -> mk_con "Deref" [ string_of_expr e ]
+  | Assign (_, e1, e2) ->
+      mk_con "Assign" [ string_of_expr e1; string_of_expr e2 ]
+  | Lambda (_, (x, t, e)) ->
+      mk_con "Lambda" [ x; string_of_type t; string_of_expr e ]
+  | App (_, e1, e2) -> mk_con "App" [ string_of_expr e1; string_of_expr e2 ]
+  | Let (_, x, t, e1, e2) ->
+      mk_con "Let" [ x; string_of_type t; string_of_expr e1; string_of_expr e2 ]
+  | LetFun (_, f, (x, t1, e1), t2, e2) ->
+      mk_con "LetFun"
+        [
+          f;
+          mk_con "" [ x; string_of_type t1; string_of_expr e1 ];
+          string_of_type t2;
+          string_of_expr e2;
+        ]
+  | LetRecFun (_, f, (x, t1, e1), t2, e2) ->
+      mk_con "LetRecFun"
+        [
+          f;
+          mk_con "" [ x; string_of_type t1; string_of_expr e1 ];
+          string_of_type t2;
+          string_of_expr e2;
+        ]
+  | Case (_, e, (x1, t1, e1), (x2, _, e2)) ->
+      mk_con "Case"
+        [
+          string_of_expr e;
+          mk_con "" [ x1; string_of_type t1; string_of_expr e1 ];
+          mk_con "" [ x2; string_of_type t1; string_of_expr e2 ];
+        ]
 
-let rec string_of_type = function 
-  | TEint             -> "TEint" 
-  | TEbool            -> "TEbool" 
-  | TEunit            -> "TEunit" 
-  | TEref t           -> mk_con "TEref" [string_of_type t] 
-  | TEarrow(t1, t2)   -> mk_con "TEarrow" [string_of_type t1; string_of_type t2] 
-  | TEproduct(t1, t2) -> mk_con "TEproduct" [string_of_type t1; string_of_type t2] 
-  | TEunion(t1, t2)   -> mk_con "TEunion" [string_of_type t1; string_of_type t2] 
-
-let rec string_of_expr = function 
-    | Unit _              -> "Unit" 
-    | What _              -> "What" 
-    | Var (_, x)          -> mk_con "Var" [x] 
-    | Integer (_, n)      -> mk_con "Integer" [string_of_int n] 
-    | Boolean (_, b)      -> mk_con "Boolean" [string_of_bool b] 
-    | UnaryOp(_, op, e)   -> mk_con "UnaryOp" [string_of_uop op; string_of_expr e]
-    | Op(_, e1, op, e2)   -> mk_con "Op" [string_of_expr e1; string_of_bop op; string_of_expr e2]
-    | If(_, e1, e2, e3)   -> mk_con "If" [string_of_expr e1; string_of_expr e2; string_of_expr e3]
-    | Pair(_, e1, e2)     -> mk_con "Pair" [string_of_expr e1; string_of_expr e2]
-    | Fst(_, e)           -> mk_con "Fst" [string_of_expr e] 
-    | Snd(_, e)           -> mk_con "Snd" [string_of_expr e] 
-    | Inl(_, _, e)        -> mk_con "Inl" [string_of_expr e] 
-    | Inr(_, _, e)        -> mk_con "Inr" [string_of_expr e] 
-    | Seq (_, el)         -> mk_con "Seq" [string_of_expr_list el] 
-    | While (_, e1, e2)   -> mk_con "While" [string_of_expr e1; string_of_expr e2]
-    | Ref(_, e)           -> mk_con "Ref" [string_of_expr e] 
-    | Deref(_, e)         -> mk_con "Deref" [string_of_expr e] 
-    | Assign(_, e1, e2)   -> mk_con "Assign" [string_of_expr e1; string_of_expr e2]
-    | Lambda(_, (x, t, e)) -> mk_con "Lambda" [x; string_of_type t; string_of_expr e]
-    | App(_, e1, e2)      -> mk_con "App" [string_of_expr e1; string_of_expr e2]
-    | Let(_, x, t, e1, e2) -> mk_con "Let" [x; string_of_type t; string_of_expr e1; string_of_expr e2]
-    | LetFun(_, f, (x, t1, e1), t2, e2)      -> 
-          mk_con "LetFun" [
-             f; 
-             mk_con "" [x; string_of_type t1; string_of_expr e1]; 
-             string_of_type t2; 
-             string_of_expr e2]
-    | LetRecFun(_, f, (x, t1, e1), t2, e2)   -> 
-          mk_con "LetRecFun" [
-             f; 
-             mk_con "" [x; string_of_type t1; string_of_expr e1]; 
-             string_of_type t2; 
-             string_of_expr e2]
-    | Case(_, e, (x1, t1, e1), (x2, _, e2)) -> 
-          mk_con "Case" [
-	     string_of_expr e; 
-	     mk_con "" [x1; string_of_type t1; string_of_expr e1]; 
-	     mk_con "" [x2; string_of_type t1; string_of_expr e2]]
-
-and string_of_expr_list = function 
-  | [] -> "" 
-  | [e] -> string_of_expr e 
-  |  e:: rest -> (string_of_expr e ) ^ "; " ^ (string_of_expr_list rest)
+and string_of_expr_list = function
+  | [] -> ""
+  | [ e ] -> string_of_expr e
+  | e :: rest -> string_of_expr e ^ "; " ^ string_of_expr_list rest

--- a/slang/past.mli
+++ b/slang/past.mli
@@ -2,51 +2,48 @@
    The Parsed AST
 *)
 type var = string
-
 type loc = Lexing.position
 
 type type_expr =
-   | TEint
-   | TEbool
-   | TEunit
-   | TEref of type_expr
-   | TEarrow of type_expr * type_expr
-   | TEproduct of type_expr * type_expr
-   | TEunion of type_expr * type_expr
+  | TEint
+  | TEbool
+  | TEunit
+  | TEref of type_expr
+  | TEarrow of type_expr * type_expr
+  | TEproduct of type_expr * type_expr
+  | TEunion of type_expr * type_expr
 
 type oper = ADD | MUL | DIV | SUB | LT | AND | OR | EQ | EQB | EQI
-
 type unary_oper = NEG | NOT
 
 type expr =
-       | Unit of loc
-       | What of loc
-       | Var of loc * var
-       | Integer of loc * int
-       | Boolean of loc * bool
-       | UnaryOp of loc * unary_oper * expr
-       | Op of loc * expr * oper * expr
-       | If of loc * expr * expr * expr
-       | Pair of loc * expr * expr
-       | Fst of loc * expr
-       | Snd of loc * expr
-       | Inl of loc * type_expr * expr
-       | Inr of loc * type_expr * expr
-       | Case of loc * expr * lambda * lambda
-
-       | While of loc * expr * expr
-       | Seq of loc * (expr list)
-       | Ref of loc * expr
-       | Deref of loc * expr
-       | Assign of loc * expr * expr
-
-       | Lambda of loc * lambda
-       | App of loc * expr * expr
-       | Let of loc * var * type_expr * expr * expr
-       | LetFun of loc * var * lambda * type_expr * expr
-       | LetRecFun of loc * var * lambda * type_expr * expr
+  | Unit of loc
+  | What of loc
+  | Var of loc * var
+  | Integer of loc * int
+  | Boolean of loc * bool
+  | UnaryOp of loc * unary_oper * expr
+  | Op of loc * expr * oper * expr
+  | If of loc * expr * expr * expr
+  | Pair of loc * expr * expr
+  | Fst of loc * expr
+  | Snd of loc * expr
+  | Inl of loc * type_expr * expr
+  | Inr of loc * type_expr * expr
+  | Case of loc * expr * lambda * lambda
+  | While of loc * expr * expr
+  | Seq of loc * expr list
+  | Ref of loc * expr
+  | Deref of loc * expr
+  | Assign of loc * expr * expr
+  | Lambda of loc * lambda
+  | App of loc * expr * expr
+  | Let of loc * var * type_expr * expr * expr
+  | LetFun of loc * var * lambda * type_expr * expr
+  | LetRecFun of loc * var * lambda * type_expr * expr
 
 and lambda = var * type_expr * expr
+
 val loc_of_expr : expr -> loc
 val string_of_loc : loc -> string
 
@@ -57,5 +54,3 @@ val string_of_type : type_expr -> string
 val string_of_expr : expr -> string
 val print_expr : expr -> unit
 val eprint_expr : expr -> unit
-
-

--- a/slang/past_to_ast.ml
+++ b/slang/past_to_ast.ml
@@ -1,5 +1,3 @@
-
-
 (*   translate_expr : Past.expr -> Ast.expr
      Translates parsed AST to internal AST :
      1) drop types
@@ -11,9 +9,7 @@
 
 *)
 
-let translate_uop = function
-  | Past.NEG -> Ast.NEG
-  | Past.NOT -> Ast.NOT
+let translate_uop = function Past.NEG -> Ast.NEG | Past.NOT -> Ast.NOT
 
 let translate_bop = function
   | Past.ADD -> Ast.ADD
@@ -25,42 +21,45 @@ let translate_bop = function
   | Past.OR -> Ast.OR
   | Past.EQI -> Ast.EQI
   | Past.EQB -> Ast.EQB
-  | Past.EQ  -> Errors.complain "internal error, translate found a EQ that should have been resolved to EQI or EQB"
-
+  | Past.EQ ->
+      Errors.complain
+        "internal error, translate found a EQ that should have been resolved \
+         to EQI or EQB"
 
 let rec translate_expr = function
-    | Past.Unit _           -> Ast.Unit
-    | Past.What _           -> Ast.UnaryOp(Ast.READ, Ast.Unit)
-    | Past.Var (_, x)          -> Ast.Var(x)
-    | Past.Integer (_, n)      -> Ast.Integer(n)
-    | Past.Boolean (_, b)      -> Ast.Boolean(b)
-    | Past.UnaryOp (_, op, e)  -> Ast.UnaryOp(translate_uop op, translate_expr e)
-    | Past.Op (_, e1, op, e2)  -> Ast.Op(translate_expr e1, translate_bop op, translate_expr e2)
-    | Past.If (_, e1, e2, e3)  -> Ast.If(translate_expr e1, translate_expr e2, translate_expr e3)
-    | Past.Pair (_, e1, e2)    -> Ast.Pair(translate_expr e1, translate_expr e2)
-    | Past.Fst (_, e)          -> Ast.Fst(translate_expr e)
-    | Past.Snd (_, e)          -> Ast.Snd(translate_expr e)
-    | Past.Inl (_, _, e)       -> Ast.Inl(translate_expr e)
-    | Past.Inr (_, _, e)       -> Ast.Inr(translate_expr e)
-    | Past.Case (_, e, l1, l2) ->
-       Ast.Case(translate_expr e, translate_lambda l1, translate_lambda l2)
-    | Past.Lambda (_, lam)     -> Ast.Lambda (translate_lambda lam)
-    | Past.App (_, e1, e2)     -> Ast.App(translate_expr e1, translate_expr e2)
-    (*
+  | Past.Unit _ -> Ast.Unit
+  | Past.What _ -> Ast.UnaryOp (Ast.READ, Ast.Unit)
+  | Past.Var (_, x) -> Ast.Var x
+  | Past.Integer (_, n) -> Ast.Integer n
+  | Past.Boolean (_, b) -> Ast.Boolean b
+  | Past.UnaryOp (_, op, e) -> Ast.UnaryOp (translate_uop op, translate_expr e)
+  | Past.Op (_, e1, op, e2) ->
+      Ast.Op (translate_expr e1, translate_bop op, translate_expr e2)
+  | Past.If (_, e1, e2, e3) ->
+      Ast.If (translate_expr e1, translate_expr e2, translate_expr e3)
+  | Past.Pair (_, e1, e2) -> Ast.Pair (translate_expr e1, translate_expr e2)
+  | Past.Fst (_, e) -> Ast.Fst (translate_expr e)
+  | Past.Snd (_, e) -> Ast.Snd (translate_expr e)
+  | Past.Inl (_, _, e) -> Ast.Inl (translate_expr e)
+  | Past.Inr (_, _, e) -> Ast.Inr (translate_expr e)
+  | Past.Case (_, e, l1, l2) ->
+      Ast.Case (translate_expr e, translate_lambda l1, translate_lambda l2)
+  | Past.Lambda (_, lam) -> Ast.Lambda (translate_lambda lam)
+  | Past.App (_, e1, e2) -> Ast.App (translate_expr e1, translate_expr e2)
+  (*
        Replace "let" with abstraction and application. For example, translate
         "let x = e1 in e2 end" to "(fun x -> e2) e1"
     *)
-    | Past.Let (_, x, _, e1, e2) ->
-         Ast.App(Ast.Lambda(x, translate_expr e2), translate_expr e1)
-    | Past.LetFun (_, f, lam, _, e)     ->
-         Ast.LetFun(f, translate_lambda lam, translate_expr e)
-    | Past.LetRecFun (_, f, lam, _, e)     ->
-         Ast.LetRecFun(f, translate_lambda lam, translate_expr e)
-
-    | Past.Seq (_, el) -> Ast.Seq(List.map translate_expr el)
-    | Past.While (_, e1, e2) -> Ast.While(translate_expr e1, translate_expr e2)
-    | Past.Ref (_, e) -> Ast.Ref(translate_expr e)
-    | Past.Deref (_, e) -> Ast.Deref(translate_expr e)
-    | Past.Assign (_, e1, e2) -> Ast.Assign(translate_expr e1, translate_expr e2)
+  | Past.Let (_, x, _, e1, e2) ->
+      Ast.App (Ast.Lambda (x, translate_expr e2), translate_expr e1)
+  | Past.LetFun (_, f, lam, _, e) ->
+      Ast.LetFun (f, translate_lambda lam, translate_expr e)
+  | Past.LetRecFun (_, f, lam, _, e) ->
+      Ast.LetRecFun (f, translate_lambda lam, translate_expr e)
+  | Past.Seq (_, el) -> Ast.Seq (List.map translate_expr el)
+  | Past.While (_, e1, e2) -> Ast.While (translate_expr e1, translate_expr e2)
+  | Past.Ref (_, e) -> Ast.Ref (translate_expr e)
+  | Past.Deref (_, e) -> Ast.Deref (translate_expr e)
+  | Past.Assign (_, e1, e2) -> Ast.Assign (translate_expr e1, translate_expr e2)
 
 and translate_lambda (x, _, body) = (x, translate_expr body)

--- a/slang/past_to_ast.mli
+++ b/slang/past_to_ast.mli
@@ -1,2 +1,1 @@
-
 val translate_expr : Past.expr -> Ast.expr

--- a/slang/pptree.ml
+++ b/slang/pptree.ml
@@ -1,26 +1,35 @@
 (* Pretty Printing without brackets*)
 let string_replace_char s c_from c_to =
   let char_map i =
-    if s.[i] = c_from
-    then c_to
-    else s.[i] in
-  String.init (String.length s) char_map;;
-let tail s = (String.sub s 1 ( (String.length s) - 1))
+    if s.[i] = c_from then
+      c_to
+    else
+      s.[i]
+  in
+  String.init (String.length s) char_map
+
+let tail s = String.sub s 1 (String.length s - 1)
+
 let pp_no_bracket str =
   let rec aux output indent_list left =
     match left with
     | "" -> output
-    | x -> match x.[0] with
-      | '(' ->
-        let old_indent = List.hd indent_list in
-        let new_indent = (string_replace_char old_indent '-' ' ') ^ "|- " in
-        aux (output ^ "\n" ^ new_indent) (new_indent::indent_list) (tail left)
-      | ',' -> aux (output ^ "\n" ^ (List.hd indent_list)) indent_list (tail left)
-      | ')' -> aux output (List.tl indent_list) (tail left)
-      | ' ' -> aux output indent_list (tail left)
-      | c -> aux (output ^ (Char.escaped c)) indent_list (tail left)
-  in aux "" [""] str
-
+    | x -> (
+        match x.[0] with
+        | '(' ->
+            let old_indent = List.hd indent_list in
+            let new_indent = string_replace_char old_indent '-' ' ' ^ "|- " in
+            aux
+              (output ^ "\n" ^ new_indent)
+              (new_indent :: indent_list)
+              (tail left)
+        | ',' ->
+            aux (output ^ "\n" ^ List.hd indent_list) indent_list (tail left)
+        | ')' -> aux output (List.tl indent_list) (tail left)
+        | ' ' -> aux output indent_list (tail left)
+        | c -> aux (output ^ Char.escaped c) indent_list (tail left))
+  in
+  aux "" [ "" ] str
 
 (* let test_str = "LetRecFun(fib, (m, If(Op(Var(m), EQI, Integer(0)), Integer(1), If(Op(Var(m), EQI, Integer(1)), Integer(1), Op(App(Var(fib), Op (Var(m), SUB, Integer(1))), ADD, App(Var(fib), Op(Var(m), SUB, Integer(2))))))), App(Var(fib), UnaryOp(READ, Unit)))" *)
 (* let _ = print_string (pp_no_bracket test_str) *)

--- a/slang/slang.ml
+++ b/slang/slang.ml
@@ -9,11 +9,12 @@ open Slanglib
 
 (*  This is the main file. *)
 
-let error file action s = print_string ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n")
+let error file action s =
+  print_string ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n")
 
 let fatal_error file action s =
   error file action s;
-  exit(-1)
+  exit (-1)
 
 (* bind interpreters *)
 (* each interpreter i_ has type "(string * Ast.expr) -> string option" *)
@@ -22,50 +23,79 @@ let wrap file e interpret msg =
   match interpret e with
   | v -> Some v
   | exception Errors.Error s ->
-     error file msg s;
-     None
+      error file msg s;
+      None
   | exception exc ->
-     fatal_error file msg ("Exception: " ^ (Printexc.to_string exc))
+      fatal_error file msg ("Exception: " ^ Printexc.to_string exc)
 
-let i0 (file, e)   = wrap file e (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x)) "Interpreter 0"
-let i1 (file, e)   = wrap file e (fun x -> Interp_1.string_of_value (Interp_1.interpret x)) "Interpreter 1"
-let i2 (file, e)   = wrap file e (fun x -> Interp_2.string_of_value (fst (Interp_2.interpret x))) "Interpreter 2"
-let i3 (file, e)   = wrap file e (fun x -> Interp_3.string_of_value (Interp_3.interpret x)) "Interpreter 3"
-let i4 (file, e)   = wrap file e (fun x -> Jargon.string_of_value (Jargon.interpret x)) "Jargon VM"
+let i0 (file, e) =
+  wrap file e
+    (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x))
+    "Interpreter 0"
 
-let i4x86 (_, e)   = let _ = Jargon_to_x86.emit_x86 e in None
+let i1 (file, e) =
+  wrap file e
+    (fun x -> Interp_1.string_of_value (Interp_1.interpret x))
+    "Interpreter 1"
+
+let i2 (file, e) =
+  wrap file e
+    (fun x -> Interp_2.string_of_value (fst (Interp_2.interpret x)))
+    "Interpreter 2"
+
+let i3 (file, e) =
+  wrap file e
+    (fun x -> Interp_3.string_of_value (Interp_3.interpret x))
+    "Interpreter 3"
+
+let i4 (file, e) =
+  wrap file e (fun x -> Jargon.string_of_value (Jargon.interpret x)) "Jargon VM"
+
+let i4x86 (_, e) =
+  let _ = Jargon_to_x86.emit_x86 e in
+  None
 
 (* show compiled code *)
-let i2cc (_, e)   = let () = print_endline (Interp_2.string_of_code (Interp_2.compile e)) in None
-let i3cc (_, e)   = let () = print_endline (Interp_3.string_of_code (Interp_3.compile e)) in None
-let i4cc (_, e)   = let () = print_endline (Jargon.string_of_listing (Jargon.compile e)) in None
+let i2cc (_, e) =
+  let () = print_endline (Interp_2.string_of_code (Interp_2.compile e)) in
+  None
 
-let interpreters = [
+let i3cc (_, e) =
+  let () = print_endline (Interp_3.string_of_code (Interp_3.compile e)) in
+  None
+
+let i4cc (_, e) =
+  let () = print_endline (Jargon.string_of_listing (Jargon.compile e)) in
+  None
+
+let interpreters =
+  [
     (* use-flag, the action, a description string *)
-    (Option.use_i0,                              i0,   "Interpreter 0");
-    (Option.use_i1,                              i1,   "Interpreter 1");
-    (Option.use_i2 && not(Option.show_compiled), i2,   "Interpreter 2");
-    (Option.show_compiled && Option.use_i2     , i2cc, "Interpreter 2, compiled code");
-    (Option.use_i3 && not(Option.show_compiled), i3,   "Interpreter 3");
-    (Option.show_compiled && Option.use_i3     , i3cc, "Interpreter 3, compiled code");
-    (Option.use_i4 && not(Option.show_compiled), i4,   "Jargon VM"    );
-    (Option.use_i4x86 ,                          i4x86,"Jargon code to x86");
-    (Option.show_compiled && Option.use_i4     , i4cc, "Jargon, compiled code")
-]
+    (Option.use_i0, i0, "Interpreter 0");
+    (Option.use_i1, i1, "Interpreter 1");
+    (Option.use_i2 && not Option.show_compiled, i2, "Interpreter 2");
+    (Option.show_compiled && Option.use_i2, i2cc, "Interpreter 2, compiled code");
+    (Option.use_i3 && not Option.show_compiled, i3, "Interpreter 3");
+    (Option.show_compiled && Option.use_i3, i3cc, "Interpreter 3, compiled code");
+    (Option.use_i4 && not Option.show_compiled, i4, "Jargon VM");
+    (Option.use_i4x86, i4x86, "Jargon code to x86");
+    (Option.show_compiled && Option.use_i4, i4cc, "Jargon, compiled code");
+  ]
 
 let show_output describe string_out =
-  if not Option.run_tests
-  then begin
-      (if Option.verbose then print_string ("\n" ^  describe ^ " \n"));
-      print_string ("output> " ^ string_out ^ "\n")
-    end
+  if not Option.run_tests then begin
+    if Option.verbose then
+      print_string ("\n" ^ describe ^ " \n");
+    print_string ("output> " ^ string_out ^ "\n")
+  end
 
 (* used for -t option *)
 let check_expected describe file string_out = function
   | None -> ()
   | Some expected when string_out = expected -> ()
-  | Some expected -> error file "testing"
-                       (describe ^ " computed " ^ string_out ^ ", but expected " ^ expected)
+  | Some expected ->
+      error file "testing"
+        (describe ^ " computed " ^ string_out ^ ", but expected " ^ expected)
 
 (* runs all interpreters on expression e : Ast.expr.
    If expected_option = Some (expected), then
@@ -73,27 +103,29 @@ let check_expected describe file string_out = function
 *)
 let rec run_interpreters file e expected_option = function
   | [] -> ()
-  | (true, interp, describe) :: rest ->
-     (match interp (file, e) with
+  | (true, interp, describe) :: rest -> (
+      match interp (file, e) with
       | None -> run_interpreters file e expected_option rest
       | Some string_out ->
-         let () = show_output describe string_out in
-         let () = check_expected describe file string_out expected_option in
-         run_interpreters file e expected_option rest)
-  | (false, _, _) :: rest ->
-     run_interpreters file e expected_option rest
+          let () = show_output describe string_out in
+          let () = check_expected describe file string_out expected_option in
+          run_interpreters file e expected_option rest)
+  | (false, _, _) :: rest -> run_interpreters file e expected_option rest
 
 (* process_inputs : runs all (flagged) interpreters on all inputs *)
 let process_input (file, expected) =
-   try
-      let e = Front_end.front_end file in
-      run_interpreters file e expected interpreters
-   with
-      Errors.Error s -> error file "Front_end" s
+  try
+    let e = Front_end.front_end file in
+    run_interpreters file e expected interpreters
+  with Errors.Error s -> error file "Front_end" s
+
 let process_inputs = List.iter process_input
 
-let () = process_inputs
-        (if Option.run_tests
-        then (try Tests.get_all_tests ()
-              with Errors.Error s -> fatal_error "tests/" "Test.get_all_tests" s)
-        else [(Option.infile, None)])
+let () =
+  process_inputs
+    (if Option.run_tests then
+       try
+         Tests.get_all_tests ()
+       with Errors.Error s -> fatal_error "tests/" "Test.get_all_tests" s
+     else
+       [ (Option.infile, None) ])

--- a/slang/static.ml
+++ b/slang/static.ml
@@ -7,9 +7,7 @@ let internal_error msg = complainf "INTERNAL ERROR: %s" msg
 
 let report_expecting e msg t =
   let loc = loc_of_expr e in
-  complainf "ERROR at location %s\n\
-             Expression %s\n\
-             has type %s, but expecting %s"
+  complainf "ERROR at location %s\nExpression %s\nhas type %s, but expecting %s"
     (string_of_loc loc) (string_of_expr e) (string_of_type t) msg
 
 let report_types_not_equal loc t1 t2 =
@@ -17,122 +15,128 @@ let report_types_not_equal loc t1 t2 =
     (string_of_loc loc) (string_of_type t1) (string_of_type t2)
 
 let report_type_mismatch (e1, t1) (e2, t2) =
-    let loc1 = loc_of_expr e1 and loc2 = loc_of_expr e2 in
-    complainf "ERROR, Type Mismatch: expecting equal types, however\n\
-              at location %s\n\
-              expression %s\n\
-              has type %s and at location %s\n\
-              expression %s\n\
-              has type %s"
-      (string_of_loc loc1) (string_of_expr e1) (string_of_type t1)
-      (string_of_loc loc2) (string_of_expr e2) (string_of_type t2)
+  let loc1 = loc_of_expr e1 and loc2 = loc_of_expr e2 in
+  complainf
+    "ERROR, Type Mismatch: expecting equal types, however\n\
+     at location %s\n\
+     expression %s\n\
+     has type %s and at location %s\n\
+     expression %s\n\
+     has type %s"
+    (string_of_loc loc1) (string_of_expr e1) (string_of_type t1)
+    (string_of_loc loc2) (string_of_expr e2) (string_of_type t2)
 
 let rec find loc x = function
-  | []                     -> complainf "%s is not defined at %s" x (string_of_loc loc)
+  | [] -> complainf "%s is not defined at %s" x (string_of_loc loc)
   | (y, v) :: _ when x = y -> v
-  | _      :: rest         -> find loc x rest
+  | _ :: rest -> find loc x rest
 
 (* may want to make this more interesting someday ... *)
 let ty_eq t1 t2 = t1 = t2
+let make_pair loc (e1, t1) (e2, t2) = (Pair (loc, e1, e2), TEproduct (t1, t2))
+let make_inl loc t2 (e, t1) = (Inl (loc, t2, e), TEunion (t1, t2))
+let make_inr loc t1 (e, t2) = (Inr (loc, t1, e), TEunion (t1, t2))
+let make_lambda loc x t1 (e, t2) = (Lambda (loc, (x, t1, e)), TEarrow (t1, t2))
+let make_ref loc (e, t) = (Ref (loc, e), TEref t)
 
-let make_pair loc (e1, t1) (e2, t2)  = Pair (loc, e1, e2), TEproduct(t1, t2)
-let make_inl loc t2 (e, t1)          = Inl (loc, t2, e), TEunion(t1, t2)
-let make_inr loc t1 (e, t2)          = Inr (loc, t1, e), TEunion(t1, t2)
-let make_lambda loc x t1 (e, t2)     = Lambda (loc, (x, t1, e)), TEarrow(t1, t2)
-let make_ref loc (e, t)              = Ref (loc, e), TEref t
 let make_letfun loc f x t1 t2 (body, t2') (e, t) =
   match ty_eq t2 t2' with
-  | true  -> LetFun (loc, f, (x, t1, body), t2, e), t
-  | false -> report_expecting body (string_of_type t2) t2'
-let make_letrecfun loc f x t1 t2 (body, t2') (e, t) =
-  match ty_eq t2 t2' with
-  | true  -> LetRecFun (loc, f, (x, t1, body), t2, e), t
+  | true -> (LetFun (loc, f, (x, t1, body), t2, e), t)
   | false -> report_expecting body (string_of_type t2) t2'
 
-let make_let loc x t (e1, t1) (e2, t2)  =
-  if ty_eq t t1
-  then Let (loc, x, t, e1, e2), t2
-  else report_types_not_equal loc t t1
+let make_letrecfun loc f x t1 t2 (body, t2') (e, t) =
+  match ty_eq t2 t2' with
+  | true -> (LetRecFun (loc, f, (x, t1, body), t2, e), t)
+  | false -> report_expecting body (string_of_type t2) t2'
+
+let make_let loc x t (e1, t1) (e2, t2) =
+  if ty_eq t t1 then
+    (Let (loc, x, t, e1, e2), t2)
+  else
+    report_types_not_equal loc t t1
 
 let make_if loc (e1, t1) (e2, t2) (e3, t3) =
   match t1 with
-  | TEbool when ty_eq t2 t3 -> If (loc, e1, e2, e3), t2
-  | TEbool                  -> report_type_mismatch (e2, t2) (e3, t3)
-  | ty                      -> report_expecting e1 "boolean" ty
+  | TEbool when ty_eq t2 t3 -> (If (loc, e1, e2, e3), t2)
+  | TEbool -> report_type_mismatch (e2, t2) (e3, t3)
+  | ty -> report_expecting e1 "boolean" ty
 
 let make_app loc (e1, t1) (e2, t2) =
   match t1 with
-  | TEarrow(t3, t4) when ty_eq t2 t3 -> App(loc, e1, e2), t4
-  | TEarrow(t3, _)                   -> report_expecting e2 (string_of_type t3) t2
-  | _                                -> report_expecting e1 "function type" t1
+  | TEarrow (t3, t4) when ty_eq t2 t3 -> (App (loc, e1, e2), t4)
+  | TEarrow (t3, _) -> report_expecting e2 (string_of_type t3) t2
+  | _ -> report_expecting e1 "function type" t1
 
 let make_fst loc = function
-  | e, TEproduct(t, _) -> Fst (loc, e), t
-  | e, t               -> report_expecting e "product" t
+  | e, TEproduct (t, _) -> (Fst (loc, e), t)
+  | e, t -> report_expecting e "product" t
 
 let make_snd loc = function
-  | e, TEproduct(_, t) -> Snd (loc, e), t
-  | e, t               -> report_expecting e "product" t
+  | e, TEproduct (_, t) -> (Snd (loc, e), t)
+  | e, t -> report_expecting e "product" t
 
 let make_deref loc = function
-  | e, TEref t' -> Deref (loc, e), t'
-  | e, t        -> report_expecting e "ref type" t
+  | e, TEref t' -> (Deref (loc, e), t')
+  | e, t -> report_expecting e "ref type" t
 
 let make_uop loc uop (e, t) =
-  match uop, t with
-  | NEG, TEint  -> UnaryOp (loc, uop, e), t
-  | NEG, _      -> report_expecting e "integer" t
-  | NOT, TEbool -> UnaryOp (loc, uop, e), t
-  | NOT, _      -> report_expecting e "boolean" t
+  match (uop, t) with
+  | NEG, TEint -> (UnaryOp (loc, uop, e), t)
+  | NEG, _ -> report_expecting e "integer" t
+  | NOT, TEbool -> (UnaryOp (loc, uop, e), t)
+  | NOT, _ -> report_expecting e "boolean" t
 
 let make_bop loc bop (e1, t1) (e2, t2) =
-  match bop, t1, t2 with
-  | LT,  TEint,  TEint  -> Op (loc, e1, bop, e2), TEbool
-  | LT,  TEint,  t      -> report_expecting e2 "integer" t
-  | LT,  t,      _      -> report_expecting e1 "integer" t
-  | ADD, TEint,  TEint  -> Op (loc, e1, bop, e2), t1
-  | ADD, TEint,  t      -> report_expecting e2 "integer" t
-  | ADD, t,      _      -> report_expecting e1 "integer" t
-  | SUB, TEint,  TEint  -> Op (loc, e1, bop, e2), t1
-  | SUB, TEint,  t      -> report_expecting e2 "integer" t
-  | SUB, t,      _      -> report_expecting e1 "integer" t
-  | MUL, TEint,  TEint  -> Op (loc, e1, bop, e2), t1
-  | MUL, TEint,  t      -> report_expecting e2 "integer" t
-  | MUL, t,      _      -> report_expecting e1 "integer" t
-  | DIV, TEint,  TEint  -> Op (loc, e1, bop, e2), t1
-  | DIV, TEint,  t      -> report_expecting e2 "integer" t
-  | DIV, t,      _      -> report_expecting e1 "integer" t
-  | OR,  TEbool, TEbool -> Op (loc, e1, bop, e2), t1
-  | OR,  TEbool,  t     -> report_expecting e2 "boolean" t
-  | OR,  t,      _      -> report_expecting e1 "boolean" t
-  | AND, TEbool, TEbool -> Op (loc, e1, bop, e2), t1
-  | AND, TEbool,  t     -> report_expecting e2 "boolean" t
-  | AND, t,      _      -> report_expecting e1 "boolean" t
-  | EQ,  TEbool, TEbool -> Op (loc, e1, EQB, e2), t1
-  | EQ,  TEint,  TEint  -> Op (loc, e1, EQI, e2), TEbool
-  | EQ,  _,      _      -> report_type_mismatch (e1, t1) (e2, t2)
-  | EQI, _, _           -> internal_error "EQI found in parsed AST"
-  | EQB, _, _           -> internal_error "EQB found in parsed AST"
+  match (bop, t1, t2) with
+  | LT, TEint, TEint -> (Op (loc, e1, bop, e2), TEbool)
+  | LT, TEint, t -> report_expecting e2 "integer" t
+  | LT, t, _ -> report_expecting e1 "integer" t
+  | ADD, TEint, TEint -> (Op (loc, e1, bop, e2), t1)
+  | ADD, TEint, t -> report_expecting e2 "integer" t
+  | ADD, t, _ -> report_expecting e1 "integer" t
+  | SUB, TEint, TEint -> (Op (loc, e1, bop, e2), t1)
+  | SUB, TEint, t -> report_expecting e2 "integer" t
+  | SUB, t, _ -> report_expecting e1 "integer" t
+  | MUL, TEint, TEint -> (Op (loc, e1, bop, e2), t1)
+  | MUL, TEint, t -> report_expecting e2 "integer" t
+  | MUL, t, _ -> report_expecting e1 "integer" t
+  | DIV, TEint, TEint -> (Op (loc, e1, bop, e2), t1)
+  | DIV, TEint, t -> report_expecting e2 "integer" t
+  | DIV, t, _ -> report_expecting e1 "integer" t
+  | OR, TEbool, TEbool -> (Op (loc, e1, bop, e2), t1)
+  | OR, TEbool, t -> report_expecting e2 "boolean" t
+  | OR, t, _ -> report_expecting e1 "boolean" t
+  | AND, TEbool, TEbool -> (Op (loc, e1, bop, e2), t1)
+  | AND, TEbool, t -> report_expecting e2 "boolean" t
+  | AND, t, _ -> report_expecting e1 "boolean" t
+  | EQ, TEbool, TEbool -> (Op (loc, e1, EQB, e2), t1)
+  | EQ, TEint, TEint -> (Op (loc, e1, EQI, e2), TEbool)
+  | EQ, _, _ -> report_type_mismatch (e1, t1) (e2, t2)
+  | EQI, _, _ -> internal_error "EQI found in parsed AST"
+  | EQB, _, _ -> internal_error "EQB found in parsed AST"
 
 let make_while loc (e1, t1) (e2, t2) =
-  match t1, t2 with
-  | TEbool, TEunit -> While (loc, e1, e2), TEunit
-  | TEbool, _      -> report_expecting e2 "unit type" t2
-  | _              -> report_expecting e1 "boolean" t1
+  match (t1, t2) with
+  | TEbool, TEunit -> (While (loc, e1, e2), TEunit)
+  | TEbool, _ -> report_expecting e2 "unit type" t2
+  | _ -> report_expecting e1 "boolean" t1
 
 let make_assign loc (e1, t1) (e2, t2) =
   match t1 with
-  | TEref t when ty_eq t t2 -> Assign(loc, e1, e2), TEunit
-  | TEref t                 -> report_type_mismatch (e1, t) (e2, t2)
-  | t                       -> report_expecting e1 "ref type" t
+  | TEref t when ty_eq t t2 -> (Assign (loc, e1, e2), TEunit)
+  | TEref t -> report_type_mismatch (e1, t) (e2, t2)
+  | t -> report_expecting e1 "ref type" t
 
 let make_case loc tl tr x1 x2 (e1, t1) (e2, t2) (e3, t3) =
   match t1 with
-  | TEunion (tl', _  ) when not (ty_eq tl tl') -> report_types_not_equal loc tl tl'
-  | TEunion (_  , tr') when not (ty_eq tr tr') -> report_types_not_equal loc tr tr'
-  | TEunion (_  , _  ) when not (ty_eq t3 t2)  -> report_type_mismatch (e2, t2) (e3, t3)
-  | TEunion (_  ,   _)                         -> Case(loc, e1, (x1, tl, e2), (x2, tr, e3)), t2
-  | t                                          -> report_expecting e1 "disjoint union" t
+  | TEunion (tl', _) when not (ty_eq tl tl') ->
+      report_types_not_equal loc tl tl'
+  | TEunion (_, tr') when not (ty_eq tr tr') ->
+      report_types_not_equal loc tr tr'
+  | TEunion (_, _) when not (ty_eq t3 t2) ->
+      report_type_mismatch (e2, t2) (e3, t3)
+  | TEunion (_, _) -> (Case (loc, e1, (x1, tl, e2), (x2, tr, e3)), t2)
+  | t -> report_expecting e1 "disjoint union" t
 
 let rec fv bound : expr -> var list = function
   | Unit _ -> []
@@ -140,7 +144,7 @@ let rec fv bound : expr -> var list = function
   | Integer _ -> []
   | Boolean _ -> []
   | Var (_, x) when List.mem x bound -> []
-  | Var (_, x) -> [x]
+  | Var (_, x) -> [ x ]
   | Seq (_, el) -> List.concat_map (fv bound) el
   | Ref (_, e)
   | Deref (_, e)
@@ -148,61 +152,87 @@ let rec fv bound : expr -> var list = function
   | Fst (_, e)
   | Snd (_, e)
   | Inl (_, _, e)
-  | Inr (_, _, e) -> fv bound e
+  | Inr (_, _, e) ->
+      fv bound e
   | While (_, e1, e2)
   | Assign (_, e1, e2)
   | Op (_, e1, _, e2)
   | Pair (_, e1, e2)
-  | App (_, e1, e2) -> fv bound e1 @ fv bound e2
+  | App (_, e1, e2) ->
+      fv bound e1 @ fv bound e2
   | If (_, e1, e2, e3) -> fv bound e1 @ fv bound e2 @ fv bound e3
-  | Case (_, e, (x, _, e1), (y, _, e2)) -> fv bound e @ fv (x :: bound) e1 @ fv (y :: bound) e2
-  | Lambda (_, (x, _, e))               -> fv (x :: bound) e
-  | Let (_, x, _, e1, e2)               -> fv bound e1 @ fv (x :: bound) e2
-  | LetFun (_, f, (x, _, body), _, e) -> (* Functions are implicitly recursive *)
-     fv (f :: x :: bound) body @ fv (f :: bound) e
+  | Case (_, e, (x, _, e1), (y, _, e2)) ->
+      fv bound e @ fv (x :: bound) e1 @ fv (y :: bound) e2
+  | Lambda (_, (x, _, e)) -> fv (x :: bound) e
+  | Let (_, x, _, e1, e2) -> fv bound e1 @ fv (x :: bound) e2
+  | LetFun (_, f, (x, _, body), _, e) ->
+      (* Functions are implicitly recursive *)
+      fv (f :: x :: bound) body @ fv (f :: bound) e
   | LetRecFun _ -> internal_error "LetRecFun found in parsed AST"
 
 let rec elaborate env e =
   match e with
-  | Unit _                                -> e, TEunit
-  | What _                                -> e, TEint
-  | Integer _                             -> e, TEint
-  | Boolean _                             -> e, TEbool
-  | Var (loc, x)                          -> e, find loc x env
-  | Seq (loc, el)                         -> elaborate_seq loc env el
-  | While (loc, e1, e2)                   -> make_while loc (elaborate env e1) (elaborate env e2)
-  | Ref (loc, e)                          -> make_ref loc (elaborate env e)
-  | Deref (loc, e)                        -> make_deref loc (elaborate env e)
-  | Assign (loc, e1, e2)                  -> make_assign loc (elaborate env e1) (elaborate env e2)
-  | UnaryOp (loc, uop, e)                 -> make_uop loc uop (elaborate env e)
-  | Op (loc, e1, bop, e2)                 -> make_bop loc bop (elaborate env e1) (elaborate env e2)
-  | If (loc, e1, e2, e3)                  -> make_if loc (elaborate env e1) (elaborate env e2) (elaborate env e3)
-  | Pair (loc, e1, e2)                    -> make_pair loc (elaborate env e1) (elaborate env e2)
-  | Fst (loc, e)                          -> make_fst loc (elaborate env e)
-  | Snd (loc, e)                          -> make_snd loc (elaborate env e)
-  | Inl (loc, t, e)                       -> make_inl loc t (elaborate env e)
-  | Inr (loc, t, e)                       -> make_inr loc t (elaborate env e)
-  | Case (loc, e, (x, s, e1), (y, t, e2)) -> make_case loc s t x y (elaborate env e)
-                                               (elaborate ((x, s) :: env) e1) (elaborate ((y, t) :: env) e2)
-  | Lambda (loc, (x, t, e))               -> make_lambda loc x t (elaborate ((x, t) :: env) e)
-  | App (loc, e1, e2)                     -> make_app loc (elaborate env e1) (elaborate env e2)
-  | Let (loc, x, t, e1, e2)               -> make_let loc x t (elaborate env e1) (elaborate ((x, t) :: env) e2)
+  | Unit _ -> (e, TEunit)
+  | What _ -> (e, TEint)
+  | Integer _ -> (e, TEint)
+  | Boolean _ -> (e, TEbool)
+  | Var (loc, x) -> (e, find loc x env)
+  | Seq (loc, el) -> elaborate_seq loc env el
+  | While (loc, e1, e2) -> make_while loc (elaborate env e1) (elaborate env e2)
+  | Ref (loc, e) -> make_ref loc (elaborate env e)
+  | Deref (loc, e) -> make_deref loc (elaborate env e)
+  | Assign (loc, e1, e2) ->
+      make_assign loc (elaborate env e1) (elaborate env e2)
+  | UnaryOp (loc, uop, e) -> make_uop loc uop (elaborate env e)
+  | Op (loc, e1, bop, e2) ->
+      make_bop loc bop (elaborate env e1) (elaborate env e2)
+  | If (loc, e1, e2, e3) ->
+      make_if loc (elaborate env e1) (elaborate env e2) (elaborate env e3)
+  | Pair (loc, e1, e2) -> make_pair loc (elaborate env e1) (elaborate env e2)
+  | Fst (loc, e) -> make_fst loc (elaborate env e)
+  | Snd (loc, e) -> make_snd loc (elaborate env e)
+  | Inl (loc, t, e) -> make_inl loc t (elaborate env e)
+  | Inr (loc, t, e) -> make_inr loc t (elaborate env e)
+  | Case (loc, e, (x, s, e1), (y, t, e2)) ->
+      make_case loc s t x y (elaborate env e)
+        (elaborate ((x, s) :: env) e1)
+        (elaborate ((y, t) :: env) e2)
+  | Lambda (loc, (x, t, e)) -> make_lambda loc x t (elaborate ((x, t) :: env) e)
+  | App (loc, e1, e2) -> make_app loc (elaborate env e1) (elaborate env e2)
+  | Let (loc, x, t, e1, e2) ->
+      make_let loc x t (elaborate env e1) (elaborate ((x, t) :: env) e2)
   | LetFun (loc, f, (x, t1, body), t2, e) ->
-     let env' = (f, TEarrow(t1, t2)) :: env in
-     let body' = elaborate ((x, t1) :: env') body in
-     let bound_vars_except_f =
-       x :: List.filter_map (fun (z,_) -> if z = f then None else Some x) env in
-     let make = if List.mem f (fv bound_vars_except_f body)
-                then make_letrecfun
-                else make_letfun in
-     make loc f x t1 t2 body' (elaborate env' e)
+      let env' = (f, TEarrow (t1, t2)) :: env in
+      let body' = elaborate ((x, t1) :: env') body in
+      let bound_vars_except_f =
+        x
+        :: List.filter_map
+             (fun (z, _) ->
+               if z = f then
+                 None
+               else
+                 Some x)
+             env
+      in
+      let make =
+        if List.mem f (fv bound_vars_except_f body) then
+          make_letrecfun
+        else
+          make_letfun
+      in
+      make loc f x t1 t2 body' (elaborate env' e)
   | LetRecFun _ -> internal_error "LetRecFun found in parsed AST"
 
 and elaborate_seq loc env el =
   let rec aux carry = function
-    | []        -> internal_error "empty sequence found in parsed AST"
-    | [e]       -> let (e', t) = elaborate env e in (Seq (loc, List.rev (e' :: carry )), t)
-    | e :: rest -> let (e', _) = elaborate env e in aux (e' :: carry) rest
-  in aux [] el
+    | [] -> internal_error "empty sequence found in parsed AST"
+    | [ e ] ->
+        let e', t = elaborate env e in
+        (Seq (loc, List.rev (e' :: carry)), t)
+    | e :: rest ->
+        let e', _ = elaborate env e in
+        aux (e' :: carry) rest
+  in
+  aux [] el
 
 let infer = elaborate

--- a/slang/tests.ml
+++ b/slang/tests.ml
@@ -1,26 +1,25 @@
-
-let test_dir = "tests/" 
-
+let test_dir = "tests/"
 let manifest_file = test_dir ^ "manifest.txt"
+let process_line file expected = Some (test_dir ^ file ^ ".slang", Some expected)
 
-let process_line file expected = 
-    Some(test_dir ^ file ^ ".slang", Some(expected))
+let scan_line in_chan =
+  try Scanf.bscanf in_chan "%s %s\n" process_line with
+  | End_of_file -> None
+  | ex ->
+      let _ =
+        print_string
+          ("Unexpected Scanf exception : " ^ Printexc.to_string ex ^ "\n")
+      in
+      None
 
-let scan_line in_chan = 
-    try
-       Scanf.bscanf in_chan "%s %s\n" process_line 
-    with 
-    | End_of_file -> None 
-    | ex -> let _ = print_string ("Unexpected Scanf exception : " ^ (Printexc.to_string ex) ^ "\n")
-            in None 
+let rec get_all in_chan =
+  match scan_line in_chan with
+  | None -> []
+  | Some (f, e) -> (f, e) :: get_all in_chan
 
-let rec get_all in_chan = 
-    match (scan_line in_chan) with 
-    | None -> [] 
-    | Some(f, e)  -> (f, e) :: (get_all in_chan)
-
-let get_all_tests () = 
-    let in_chan = try 
-                    Scanf.Scanning.open_in manifest_file 
-                 with _ -> Errors.complain ("can't open file " ^ manifest_file)
-    in get_all in_chan 
+let get_all_tests () =
+  let in_chan =
+    try Scanf.Scanning.open_in manifest_file
+    with _ -> Errors.complain ("can't open file " ^ manifest_file)
+  in
+  get_all in_chan

--- a/slang/tests.mli
+++ b/slang/tests.mli
@@ -1,4 +1,2 @@
-
 (* gets a list of pairs : (file name) * Some(expected output string)  *)
-val get_all_tests : unit -> (string * (string option)) list
-
+val get_all_tests : unit -> (string * string option) list

--- a/web/JargonSteps.ml
+++ b/web/JargonSteps.ml
@@ -2,51 +2,46 @@ open Slanglib
 open Jargon
 open Ast
 
-type node_tp =
-  | H_INT
-  | H_BOOL
-  | H_UNIT
-  | H_CI
-  | H_HI
-  | H_HEADER [@@deriving yojson]
+type node_tp = H_INT | H_BOOL | H_UNIT | H_CI | H_HI | H_HEADER
+[@@deriving yojson]
 
-type arrow_tp =
-  | BLOCK
-  | POINTER [@@deriving yojson]
+type arrow_tp = BLOCK | POINTER [@@deriving yojson]
 
 type node = {
-  id: string;
-  label: string;
-  parent: string;
-  tp: node_tp;
-  pointer: int option;
-} [@@deriving yojson]
+  id : string;
+  label : string;
+  parent : string;
+  tp : node_tp;
+  pointer : int option;
+}
+[@@deriving yojson]
 
-type edge = {
-  source: string;
-  target: string;
-  label:  string;
-  tp: arrow_tp;
-} [@@deriving yojson]
+type edge = { source : string; target : string; label : string; tp : arrow_tp }
+[@@deriving yojson]
 
 type graph = node list * edge list [@@deriving yojson]
 
-let string_of_heap_type tp = match tp with
+let string_of_heap_type tp =
+  match tp with
   | HT_PAIR -> "Pair"
   | HT_INL -> "InL"
   | HT_INR -> "InR"
   | HT_CLOSURE -> "Closure"
 
-let edges_of_heap (index : int) (hi : heap_item) : edge list  = match hi with
+let edges_of_heap (index : int) (hi : heap_item) : edge list =
+  match hi with
   | HEAP_INT _ -> []
   | HEAP_BOOL _ -> []
   | HEAP_UNIT -> []
-  | HEAP_HI hi -> [{
-    source = string_of_int index;
-    target = string_of_int hi;
-    label = "";
-    tp = POINTER;
-  }]
+  | HEAP_HI hi ->
+      [
+        {
+          source = string_of_int index;
+          target = string_of_int hi;
+          label = "";
+          tp = POINTER;
+        };
+      ]
   | HEAP_CI _ -> []
   (* The heap headers size also includes the header so we use i - 1 *)
   | HEAP_HEADER (_, _) -> []
@@ -56,128 +51,167 @@ let index_box index = "[ " ^ index ^ " ]"
 let node_of_heap_item index parent heap_item =
   let s_index = string_of_int index in
   let index_b = index_box s_index in
-   match heap_item with
-  | HEAP_INT i -> {
-    id      = s_index;
-    label   = index_b ^ " Int: " ^ (string_of_int i);
-    tp      = H_INT;
-    parent  = parent;
-    pointer = None;
-  }
-  | HEAP_BOOL b -> {
-    id      = s_index;
-    label   = index_b ^ " Bool: " ^ string_of_bool b;
-    tp      = H_BOOL;
-    parent  = parent;
-    pointer = None;
-  }
-  | HEAP_UNIT -> {
-    id      = s_index;
-    label   = index_b ^ "()";
-    tp      = H_UNIT;
-    parent  = parent;
-    pointer = None;
-  }
-  | HEAP_HI i -> {
-    id      = s_index;
-    label   = index_b ^ " Heap Index: " ^ string_of_int i;
-    tp      = H_HI;
-    parent  = parent;
-    pointer = Some i;
-  }
-  | HEAP_CI i -> {
-    id      = s_index;
-    label   = index_b ^ " Code Index: " ^ string_of_int i;
-    tp      = H_CI;
-    parent  = parent;
-    pointer = Some i;
-  }
-  | HEAP_HEADER (_, ht) -> {
-    id = s_index;
-    label = index_b ^ " Heap Header: " ^ string_of_heap_type ht;
-    tp    = H_HEADER;
-    parent = parent;
-    pointer = None;
-  }
+  match heap_item with
+  | HEAP_INT i ->
+      {
+        id = s_index;
+        label = index_b ^ " Int: " ^ string_of_int i;
+        tp = H_INT;
+        parent;
+        pointer = None;
+      }
+  | HEAP_BOOL b ->
+      {
+        id = s_index;
+        label = index_b ^ " Bool: " ^ string_of_bool b;
+        tp = H_BOOL;
+        parent;
+        pointer = None;
+      }
+  | HEAP_UNIT ->
+      {
+        id = s_index;
+        label = index_b ^ "()";
+        tp = H_UNIT;
+        parent;
+        pointer = None;
+      }
+  | HEAP_HI i ->
+      {
+        id = s_index;
+        label = index_b ^ " Heap Index: " ^ string_of_int i;
+        tp = H_HI;
+        parent;
+        pointer = Some i;
+      }
+  | HEAP_CI i ->
+      {
+        id = s_index;
+        label = index_b ^ " Code Index: " ^ string_of_int i;
+        tp = H_CI;
+        parent;
+        pointer = Some i;
+      }
+  | HEAP_HEADER (_, ht) ->
+      {
+        id = s_index;
+        label = index_b ^ " Heap Header: " ^ string_of_heap_type ht;
+        tp = H_HEADER;
+        parent;
+        pointer = None;
+      }
 
 let rec node_list_of_heap_item_list_ index header n = function
   | [] -> []
-  | (HEAP_HEADER (i, t))::heap_item_list ->
-      node_of_heap_item index (if n > 0 then header else "") (HEAP_HEADER (i,t)) :: node_list_of_heap_item_list_ (index + 1) (string_of_int index) (i - 1) heap_item_list
-  | heap_item::heap_item_list -> node_of_heap_item index (if n > 0 then header else "") heap_item :: node_list_of_heap_item_list_ (index + 1) header (n - 1) heap_item_list
+  | HEAP_HEADER (i, t) :: heap_item_list ->
+      node_of_heap_item index
+        (if n > 0 then
+           header
+         else
+           "")
+        (HEAP_HEADER (i, t))
+      :: node_list_of_heap_item_list_ (index + 1) (string_of_int index) (i - 1)
+           heap_item_list
+  | heap_item :: heap_item_list ->
+      node_of_heap_item index
+        (if n > 0 then
+           header
+         else
+           "")
+        heap_item
+      :: node_list_of_heap_item_list_ (index + 1) header (n - 1) heap_item_list
 
 let node_list_of_heap_item_list heap_item_list =
   node_list_of_heap_item_list_ 0 "0" 0 heap_item_list
 
-let graph_of_heap heap = (node_list_of_heap_item_list heap, List.flatten (List.mapi edges_of_heap heap))
+let graph_of_heap heap =
+  (node_list_of_heap_item_list heap, List.flatten (List.mapi edges_of_heap heap))
+
 type ret = {
-    stack : string list;
-    heap : string list;
-    heap_graph: graph;
-    sp : int;
-    fp : int;  (* frame pointer *)
-    cp : int;   (* code pointer  *)
-    hp : int;   (* next free     *)
-    status: string;
-} [@@deriving yojson]
+  stack : string list;
+  heap : string list;
+  heap_graph : graph;
+  sp : int;
+  fp : int; (* frame pointer *)
+  cp : int; (* code pointer  *)
+  hp : int; (* next free     *)
+  status : string;
+}
+[@@deriving yojson]
 
-let string_lists_of_vm_state vm_state = match vm_state with {
-    Jargon.stack = stack;
-    stack_bound = _;
-    code_bound = _;
-    heap_bound = _;
-    heap;
-    code = _;
-    sp;  (* stack pointer *)
-    fp;  (* frame pointer *)
-    cp;   (* code pointer  *)
-    hp;   (* next free     *)
-    status;
-  } -> let heap_list = Array.to_list (Array.sub heap 0 hp) in {
-    stack  = List.map Jargon.string_of_stack_item (Array.to_list (Array.sub stack 0 sp));
-    heap   = List.map Jargon.string_of_heap_item heap_list;
-    heap_graph = graph_of_heap heap_list;
-    sp;
-    fp;
-    cp;
-    hp;
-    status = Jargon.string_of_status status;
-  }
+let string_lists_of_vm_state vm_state =
+  match vm_state with
+  | {
+   Jargon.stack;
+   stack_bound = _;
+   code_bound = _;
+   heap_bound = _;
+   heap;
+   code = _;
+   sp;
+   (* stack pointer *)
+   fp;
+   (* frame pointer *)
+   cp;
+   (* code pointer  *)
+   hp;
+   (* next free     *)
+   status;
+  } ->
+      let heap_list = Array.to_list (Array.sub heap 0 hp) in
+      {
+        stack =
+          List.map Jargon.string_of_stack_item
+            (Array.to_list (Array.sub stack 0 sp));
+        heap = List.map Jargon.string_of_heap_item heap_list;
+        heap_graph = graph_of_heap heap_list;
+        sp;
+        fp;
+        cp;
+        hp;
+        status = Jargon.string_of_status status;
+      }
 
-let string_list_of_code vm_state = List.map Jargon.string_of_instruction (Array.to_list vm_state.code)
+let string_list_of_code vm_state =
+  List.map Jargon.string_of_instruction (Array.to_list vm_state.code)
 
 let rec driver n vm =
   let state = string_lists_of_vm_state vm in
-  state :: if vm.Jargon.status = Jargon.Running then driver (n+1) (step vm) else []
+  state
+  ::
+  (if vm.Jargon.status = Jargon.Running then
+     driver (n + 1) (step vm)
+   else
+     [])
 
 let steps exp =
   let c = compile exp in
   let vm = Jargon.first_frame (Jargon.initial_state c) in
   (string_list_of_code vm, driver 1 vm)
 
-let string_list_of_instruction : instruction -> (string) = function
-  | UNARY(op) -> "\tUNARY " ^ (string_of_uop op)
-  | OPER(op)  -> "\tOPER " ^ (string_of_bop op)
-  | MK_PAIR   -> "\tMK_PAIR"
-  | FST       -> "\tFST"
-  | SND       -> "\tSND"
-  | MK_INL    -> "\tMK_INL"
-  | MK_INR    -> "\tMK_INR"
-  | MK_REF    -> "\tMK_REF"
-  | PUSH(v)   -> "\tPUSH " ^ (string_of_stack_item v)
-  | LOOKUP(p) -> "\tLOOKUP " ^ (string_of_value_path p)
-  | TEST(l)   -> "\tTEST " ^ (string_of_location l)
-  | CASE(l)   -> "\tCASE " ^ (string_of_location l)
-  | GOTO(l)   -> "\tGOTO " ^ (string_of_location l)
-  | APPLY     -> "\tAPPLY"
-  | RETURN    -> "\tRETURN"
-  | HALT      -> "\tHALT"
-  | LABEL(l)  -> "LABEL " ^ l
-  | SWAP      -> "\tSWAP"
-  | POP       -> "\tPOP"
-  | DEREF     -> "\tDEREF"
-  | ASSIGN    -> "\tASSIGN"
-  | MK_CLOSURE (loc, n)
-              -> "MK_CLOSURE(" ^ (string_of_location loc) ^ ", " ^ (string_of_int n) ^ ")"
+let string_list_of_instruction : instruction -> string = function
+  | UNARY op -> "\tUNARY " ^ string_of_uop op
+  | OPER op -> "\tOPER " ^ string_of_bop op
+  | MK_PAIR -> "\tMK_PAIR"
+  | FST -> "\tFST"
+  | SND -> "\tSND"
+  | MK_INL -> "\tMK_INL"
+  | MK_INR -> "\tMK_INR"
+  | MK_REF -> "\tMK_REF"
+  | PUSH v -> "\tPUSH " ^ string_of_stack_item v
+  | LOOKUP p -> "\tLOOKUP " ^ string_of_value_path p
+  | TEST l -> "\tTEST " ^ string_of_location l
+  | CASE l -> "\tCASE " ^ string_of_location l
+  | GOTO l -> "\tGOTO " ^ string_of_location l
+  | APPLY -> "\tAPPLY"
+  | RETURN -> "\tRETURN"
+  | HALT -> "\tHALT"
+  | LABEL l -> "LABEL " ^ l
+  | SWAP -> "\tSWAP"
+  | POP -> "\tPOP"
+  | DEREF -> "\tDEREF"
+  | ASSIGN -> "\tASSIGN"
+  | MK_CLOSURE (loc, n) ->
+      "MK_CLOSURE(" ^ string_of_location loc ^ ", " ^ string_of_int n ^ ")"
 
 let string_list_of_code = List.map string_list_of_instruction

--- a/web/dune
+++ b/web/dune
@@ -1,7 +1,6 @@
 (executable
-  (name export)
-  (modes js)
-  (libraries slanglib js_of_ocaml)
-  (preprocess (pps js_of_ocaml-ppx ppx_deriving_yojson))
-)
-
+ (name export)
+ (modes js)
+ (libraries slanglib js_of_ocaml)
+ (preprocess
+  (pps js_of_ocaml-ppx ppx_deriving_yojson)))

--- a/web/export.ml
+++ b/web/export.ml
@@ -1,37 +1,70 @@
 open Js_of_ocaml
 open Slanglib
 
-let wrap interp str =
-  try interp str
-  with
-    | Errors.Error s -> s
+let wrap interp str = try interp str with Errors.Error s -> s
 
-let wrap_yojson_string f = Js.string (
-  try (Yojson.Safe.to_string (f()))
-  with Errors.Error _ -> "\"Error\""
-)
+let wrap_yojson_string f =
+  Js.string
+    (try Yojson.Safe.to_string (f ()) with Errors.Error _ -> "\"Error\"")
 
-let yojson_of_instructions x = Yojson.Safe.to_string @@ [%to_yojson: string list] @@ x
+let yojson_of_instructions x =
+  Yojson.Safe.to_string @@ [%to_yojson: string list] @@ x
 
 type egg = EGG [@@deriving yojson]
+
 let frontend str = Front_end.front_end_from_string (Js.to_string str)
+
 let _ =
   Js.export "slang"
     (object%js
-      method interp0     str = Js.string (wrap (fun x ->
-        (Interp_0.string_of_value (Interp_0.interpret_top_level (frontend x)))) str)
+       method interp0 str =
+         Js.string
+           (wrap
+              (fun x ->
+                Interp_0.string_of_value
+                  (Interp_0.interpret_top_level (frontend x)))
+              str)
 
-      method interp2     str = wrap_yojson_string (fun _ -> (
-        [%to_yojson: (string list * string list * string list) list] (Interp2.string_lists_of_steps (Interp2.steps @@ frontend str))))
-      method interp3     str = wrap_yojson_string (fun _ -> ( Interp_3.reset();
-        ([%to_yojson: string * (int * string list * string list) list] (Interp3.stacks (frontend str)))))
-      method jargon      str = wrap_yojson_string (fun _ -> (Jargon.reset();
-        ([%to_yojson: string list * JargonSteps.ret list] (JargonSteps.steps (frontend str)))))
+       method interp2 str =
+         wrap_yojson_string (fun _ ->
+             [%to_yojson: (string list * string list * string list) list]
+               (Interp2.string_lists_of_steps (Interp2.steps @@ frontend str)))
 
-      method interp2Code str = Js.string (wrap (fun x ->
-        (yojson_of_instructions @@ Interp2.string_list_of_code (Interp_2.compile (frontend x)))) str)
-      method interp3Code str = Js.string (wrap (fun x ->
-        (Interp_3.reset(); yojson_of_instructions @@ (Interp3.string_list_of_code  (Interp_3.compile (frontend x))))) str)
-      method jargonCode  str = Js.string (wrap (fun x ->
-        (Jargon.reset(); yojson_of_instructions @@ JargonSteps.string_list_of_code (Jargon.compile (frontend x)))) str)
+       method interp3 str =
+         wrap_yojson_string (fun _ ->
+             Interp_3.reset ();
+             [%to_yojson: string * (int * string list * string list) list]
+               (Interp3.stacks (frontend str)))
+
+       method jargon str =
+         wrap_yojson_string (fun _ ->
+             Jargon.reset ();
+             [%to_yojson: string list * JargonSteps.ret list]
+               (JargonSteps.steps (frontend str)))
+
+       method interp2Code str =
+         Js.string
+           (wrap
+              (fun x ->
+                yojson_of_instructions
+                @@ Interp2.string_list_of_code (Interp_2.compile (frontend x)))
+              str)
+
+       method interp3Code str =
+         Js.string
+           (wrap
+              (fun x ->
+                Interp_3.reset ();
+                yojson_of_instructions
+                @@ Interp3.string_list_of_code (Interp_3.compile (frontend x)))
+              str)
+
+       method jargonCode str =
+         Js.string
+           (wrap
+              (fun x ->
+                Jargon.reset ();
+                yojson_of_instructions
+                @@ JargonSteps.string_list_of_code (Jargon.compile (frontend x)))
+              str)
     end)

--- a/web/interp2.ml
+++ b/web/interp2.ml
@@ -6,50 +6,75 @@ type 'a steps = Interp_2.interp_state list
 
 let rec driver state =
   match state with
-    | ([], _, _) -> [state]
-    | _ -> state :: driver (Interp_2.step state)
+  | [], _, _ -> [ state ]
+  | _ -> state :: driver (Interp_2.step state)
 
 let steps e =
-  let c = Interp_2.compile e
-  in driver (c, Interp_2.initial_env, Interp_2.initial_state)
+  let c = Interp_2.compile e in
+  driver (c, Interp_2.initial_env, Interp_2.initial_state)
 
 let string_list_of_code code = List.map Interp_2.string_of_instruction code
-
 let string_list_of_env env = List.map Interp_2.string_of_env_or_value env
 
-let list_of_map m = List.of_seq @@ Seq.map (fun (_, v) -> v) @@ Interp_2.IntMap.to_seq m
+let list_of_map m =
+  List.of_seq @@ Seq.map (fun (_, v) -> v) @@ Interp_2.IntMap.to_seq m
 
-let string_list_of_heap (heap, _) = List.map Interp_2.string_of_value (list_of_map heap)
+let string_list_of_heap (heap, _) =
+  List.map Interp_2.string_of_value (list_of_map heap)
 
-let string_lists_of_steps steps = List.map (fun (c, e, s) -> (string_list_of_code c, string_list_of_env e, string_list_of_heap s)) steps
+let string_lists_of_steps steps =
+  List.map
+    (fun (c, e, s) ->
+      (string_list_of_code c, string_list_of_env e, string_list_of_heap s))
+    steps
 
-let apply_to_last f l = let length = List.length l - 1 in List.mapi (fun i x -> if length = i then f x else x) l
+let apply_to_last f l =
+  let length = List.length l - 1 in
+  List.mapi
+    (fun i x ->
+      if length = i then
+        f x
+      else
+        x)
+    l
 
-let rec string_list_of_code c =  match List.flatten @@ List.map string_list_of_instruction c with
-  | [] -> ["[]"]
-  | [s] -> ["[" ^ s ^ "]"]
-  | s :: t -> ("[" ^ s) :: (apply_to_last (fun s -> s ^ "]") t)
+let rec string_list_of_code c =
+  match List.flatten @@ List.map string_list_of_instruction c with
+  | [] -> [ "[]" ]
+  | [ s ] -> [ "[" ^ s ^ "]" ]
+  | s :: t -> ("[" ^ s) :: apply_to_last (fun s -> s ^ "]") t
 
 and string_list_of_instruction : instruction -> string list = function
-  | UNARY(op)     -> ["UNARY " ^ (string_of_uop op)]
-  | OPER(op)      -> ["OPER " ^ (string_of_bop op)]
-  | MK_PAIR       -> ["MK_PAIR"]
-  | FST           -> ["FST"]
-  | SND           -> ["SND"]
-  | MK_INL        -> ["MK_INL"]
-  | MK_INR        -> ["MK_INR"]
-  | MK_REF        -> ["MK_REF"]
-  | PUSH(v)       -> ["PUSH " ^ (string_of_value v)]
-  | LOOKUP(x)     -> ["LOOKUP " ^ x]
-  | TEST(c1, c2)  -> ("TEST(") :: (tab @@ string_list_of_code c1) @ (tab @@ string_list_of_code c2) @ [")"]
-  | CASE(c1, c2)  -> ("CASE(") :: (tab @@ string_list_of_code c1) @ (tab @@ string_list_of_code c2) @ [")"]
-  | WHILE(c1, c2) -> ("WHILE(") :: (tab @@ string_list_of_code c1) @ (tab @@ string_list_of_code c2) @ [")"]
-  | APPLY         -> ["APPLY"]
-  | BIND(x)       -> ["BIND " ^ x]
-  | SWAP          -> ["SWAP"]
-  | POP           -> ["POP"]
-  | DEREF         -> ["DEREF"]
-  | ASSIGN        -> ["ASSIGN"]
-  | MK_CLOSURE(c) -> ("MK_CLOSURE(") :: (tab @@ string_list_of_code c) @ [")"]
-  | MK_REC(f, c)  -> ("MK_REC(" ^ f ^ ", ") :: (tab @@ string_list_of_code c) @ [")"]
+  | UNARY op -> [ "UNARY " ^ string_of_uop op ]
+  | OPER op -> [ "OPER " ^ string_of_bop op ]
+  | MK_PAIR -> [ "MK_PAIR" ]
+  | FST -> [ "FST" ]
+  | SND -> [ "SND" ]
+  | MK_INL -> [ "MK_INL" ]
+  | MK_INR -> [ "MK_INR" ]
+  | MK_REF -> [ "MK_REF" ]
+  | PUSH v -> [ "PUSH " ^ string_of_value v ]
+  | LOOKUP x -> [ "LOOKUP " ^ x ]
+  | TEST (c1, c2) ->
+      ("TEST(" :: (tab @@ string_list_of_code c1))
+      @ (tab @@ string_list_of_code c2)
+      @ [ ")" ]
+  | CASE (c1, c2) ->
+      ("CASE(" :: (tab @@ string_list_of_code c1))
+      @ (tab @@ string_list_of_code c2)
+      @ [ ")" ]
+  | WHILE (c1, c2) ->
+      ("WHILE(" :: (tab @@ string_list_of_code c1))
+      @ (tab @@ string_list_of_code c2)
+      @ [ ")" ]
+  | APPLY -> [ "APPLY" ]
+  | BIND x -> [ "BIND " ^ x ]
+  | SWAP -> [ "SWAP" ]
+  | POP -> [ "POP" ]
+  | DEREF -> [ "DEREF" ]
+  | ASSIGN -> [ "ASSIGN" ]
+  | MK_CLOSURE c -> ("MK_CLOSURE(" :: (tab @@ string_list_of_code c)) @ [ ")" ]
+  | MK_REC (f, c) ->
+      (("MK_REC(" ^ f ^ ", ") :: (tab @@ string_list_of_code c)) @ [ ")" ]
+
 and tab ss = List.map (fun s -> "\t" ^ s) ss

--- a/web/interp2.mli
+++ b/web/interp2.mli
@@ -3,11 +3,10 @@ open Slanglib
 type 'a steps = Interp_2.interp_state list
 
 val steps : Ast.expr -> 'a steps
-
 val string_list_of_heap : Interp_2.state -> string list
 
-val string_lists_of_steps : 'a steps -> (string list * string list * string list) list
+val string_lists_of_steps :
+  'a steps -> (string list * string list * string list) list
 
 val string_list_of_instruction : Interp_2.instruction -> string list
-
 val string_list_of_code : Interp_2.code -> string list

--- a/web/interp3.ml
+++ b/web/interp3.ml
@@ -2,45 +2,54 @@ open Slanglib
 open Interp_3
 open Ast
 
-let string_state (cp, evs, heap_list) = (cp, List.map Interp_3.string_of_env_or_value evs, List.map Interp_3.string_of_value heap_list)
+let string_state (cp, evs, heap_list) =
+  ( cp,
+    List.map Interp_3.string_of_env_or_value evs,
+    List.map Interp_3.string_of_value heap_list )
 
-let list_of_heap _ = Array.to_list (Array.sub Interp_3.heap 0 (!Interp_3.next_address))
+let list_of_heap _ =
+  Array.to_list (Array.sub Interp_3.heap 0 !Interp_3.next_address)
 
-let rec driver n (cp, env) = let heapl = list_of_heap() in (cp, env, heapl) ::
- if Interp_3.HALT = Interp_3.get_instruction cp
-    then []
-    else driver (n + 1) (Interp_3.step (cp, env))
+let rec driver n (cp, env) =
+  let heapl = list_of_heap () in
+  (cp, env, heapl)
+  ::
+  (if Interp_3.HALT = Interp_3.get_instruction cp then
+     []
+   else
+     driver (n + 1) (Interp_3.step (cp, env)))
 
 let stacks e =
   let c = Interp_3.compile e in
   let _ = Interp_3.installed := Interp_3.load c in
-  let installed_code = Interp_3.string_of_installed_code() in
+  let installed_code = Interp_3.string_of_installed_code () in
   (installed_code, List.map string_state (driver 1 (0, [])))
 
-let string_list_of_instruction : instruction -> (string) list = function
-  | UNARY(op) -> ["UNARY " ^ (string_of_uop op)]
-  | OPER(op)  -> ["OPER " ^ (string_of_bop op)]
-  | MK_PAIR   -> ["MK_PAIR"]
-  | FST   -> ["FST"]
-  | SND   -> ["SND"]
-  | MK_INL  -> ["MK_INL"]
-  | MK_INR  -> ["MK_INR"]
-  | MK_REF  -> ["MK_REF"]
-  | PUSH(v)   -> ["PUSH " ^ (string_of_value v)]
-  | LOOKUP(x) -> ["LOOKUP " ^ x]
-  | TEST(label)   -> ["TEST " ^ (string_of_location label)]
-  | CASE(label)   -> ["CASE " ^ (string_of_location label)]
-  | GOTO(label)   -> ["GOTO " ^ (string_of_location label)]
-  | APPLY   -> ["APPLY"]
-  | RETURN  -> ["RETURN"]
-  | HALT    -> ["HALT"]
-  | BIND(x)   -> ["BIND " ^ x]
-  | LABEL(label)  -> ["LABEL " ^ label]
-  | SWAP    -> ["SWAP"]
-  | POP     -> ["POP"]
-  | DEREF   -> ["DEREF"]
-  | ASSIGN  -> ["ASSIGN"]
-  | MK_CLOSURE(loc)  -> ["MK_CLOSURE(" ^ (string_of_location loc) ^ ")"]
-  | MK_REC(v, loc) -> ["MK_REC(" ^ v ^ ", " ^ (string_of_location loc) ^ ")"]
+let string_list_of_instruction : instruction -> string list = function
+  | UNARY op -> [ "UNARY " ^ string_of_uop op ]
+  | OPER op -> [ "OPER " ^ string_of_bop op ]
+  | MK_PAIR -> [ "MK_PAIR" ]
+  | FST -> [ "FST" ]
+  | SND -> [ "SND" ]
+  | MK_INL -> [ "MK_INL" ]
+  | MK_INR -> [ "MK_INR" ]
+  | MK_REF -> [ "MK_REF" ]
+  | PUSH v -> [ "PUSH " ^ string_of_value v ]
+  | LOOKUP x -> [ "LOOKUP " ^ x ]
+  | TEST label -> [ "TEST " ^ string_of_location label ]
+  | CASE label -> [ "CASE " ^ string_of_location label ]
+  | GOTO label -> [ "GOTO " ^ string_of_location label ]
+  | APPLY -> [ "APPLY" ]
+  | RETURN -> [ "RETURN" ]
+  | HALT -> [ "HALT" ]
+  | BIND x -> [ "BIND " ^ x ]
+  | LABEL label -> [ "LABEL " ^ label ]
+  | SWAP -> [ "SWAP" ]
+  | POP -> [ "POP" ]
+  | DEREF -> [ "DEREF" ]
+  | ASSIGN -> [ "ASSIGN" ]
+  | MK_CLOSURE loc -> [ "MK_CLOSURE(" ^ string_of_location loc ^ ")" ]
+  | MK_REC (v, loc) -> [ "MK_REC(" ^ v ^ ", " ^ string_of_location loc ^ ")" ]
 
-let string_list_of_code c =  List.flatten @@ List.map string_list_of_instruction c
+let string_list_of_code c =
+  List.flatten @@ List.map string_list_of_instruction c


### PR DESCRIPTION
Adds `.ocamlformat` configuration and runs it on the entire codebase.